### PR TITLE
개인 블로그의 댓글 CRUD

### DIFF
--- a/src/main/java/me/honki12345/hoonlog/config/SecurityConfig.java
+++ b/src/main/java/me/honki12345/hoonlog/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                 .requestMatchers(antMatcher(HttpMethod.POST, "/api/v1/posts}")).authenticated()
                 .requestMatchers(antMatcher(HttpMethod.PUT, "/api/v1/posts/{\\d+}")).authenticated()
                 .requestMatchers(antMatcher(HttpMethod.DELETE, "/api/v1/posts/{\\d+}")).authenticated()
+                .requestMatchers(antMatcher(HttpMethod.POST, "/api/v1/comments}")).authenticated()
                 .anyRequest().permitAll())
             .exceptionHandling(
                 configurer -> configurer.authenticationEntryPoint(customAuthenticationEntryPoint))

--- a/src/main/java/me/honki12345/hoonlog/controller/AuthController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/AuthController.java
@@ -27,7 +27,7 @@ public class AuthController {
     @PostMapping("/token")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         UserAccountDTO userAccountDTO = userAccountService.findUserAccountAfterCheckingPassword(
-            request);
+            request.toDTO());
         TokenDTO tokenDTO = authService.createTokens(userAccountDTO);
         LoginResponse loginResponse = LoginResponse.of(tokenDTO.accessToken(),
             tokenDTO.refreshToken(), userAccountDTO.id(), userAccountDTO.username());

--- a/src/main/java/me/honki12345/hoonlog/controller/PostCommentController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostCommentController.java
@@ -1,0 +1,39 @@
+package me.honki12345.hoonlog.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import me.honki12345.hoonlog.dto.PostCommentDTO;
+import me.honki12345.hoonlog.dto.request.PostCommentRequest;
+import me.honki12345.hoonlog.dto.response.PostCommentResponse;
+import me.honki12345.hoonlog.dto.security.UserAccountPrincipal;
+import me.honki12345.hoonlog.security.jwt.util.IfLogin;
+import me.honki12345.hoonlog.service.PostCommentService;
+import me.honki12345.hoonlog.service.PostService;
+import me.honki12345.hoonlog.service.UserAccountService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/comments")
+@RestController
+public class PostCommentController {
+
+    private final PostService postService;
+    private final PostCommentService postCommentService;
+    private final UserAccountService userAccountService;
+
+    @PostMapping
+    public ResponseEntity<PostCommentResponse> addPostComment(
+        @IfLogin UserAccountPrincipal userAccountPrincipal,
+        @Valid @RequestBody PostCommentRequest request) {
+        PostCommentDTO postCommentDTO = postCommentService.addPostComment(request.toDTO(), request.postId(),
+            userAccountPrincipal.toDTO());
+
+        return new ResponseEntity<>(PostCommentResponse.from(postCommentDTO), HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/me/honki12345/hoonlog/controller/PostCommentController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostCommentController.java
@@ -8,11 +8,11 @@ import me.honki12345.hoonlog.dto.response.PostCommentResponse;
 import me.honki12345.hoonlog.dto.security.UserAccountPrincipal;
 import me.honki12345.hoonlog.security.jwt.util.IfLogin;
 import me.honki12345.hoonlog.service.PostCommentService;
-import me.honki12345.hoonlog.service.PostService;
-import me.honki12345.hoonlog.service.UserAccountService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,9 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class PostCommentController {
 
-    private final PostService postService;
     private final PostCommentService postCommentService;
-    private final UserAccountService userAccountService;
 
     @PostMapping
     public ResponseEntity<PostCommentResponse> addPostComment(
@@ -34,6 +32,17 @@ public class PostCommentController {
             userAccountPrincipal.toDTO());
 
         return new ResponseEntity<>(PostCommentResponse.from(postCommentDTO), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<PostCommentResponse> modifyPostComment(
+        @IfLogin UserAccountPrincipal userAccountPrincipal,
+        @Valid @RequestBody PostCommentRequest request,
+        @PathVariable Long commentId
+    ) {
+        PostCommentDTO postCommentDTO = postCommentService.modifyComment(request.toDTO(), commentId,
+            userAccountPrincipal.toDTO());
+        return new ResponseEntity<>(PostCommentResponse.from(postCommentDTO), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/me/honki12345/hoonlog/controller/PostCommentController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostCommentController.java
@@ -10,6 +10,7 @@ import me.honki12345.hoonlog.security.jwt.util.IfLogin;
 import me.honki12345.hoonlog.service.PostCommentService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -28,7 +29,8 @@ public class PostCommentController {
     public ResponseEntity<PostCommentResponse> addPostComment(
         @IfLogin UserAccountPrincipal userAccountPrincipal,
         @Valid @RequestBody PostCommentRequest request) {
-        PostCommentDTO postCommentDTO = postCommentService.addPostComment(request.toDTO(), request.postId(),
+        PostCommentDTO postCommentDTO = postCommentService.addPostComment(request.toDTO(),
+            request.postId(),
             userAccountPrincipal.toDTO());
 
         return new ResponseEntity<>(PostCommentResponse.from(postCommentDTO), HttpStatus.CREATED);
@@ -44,5 +46,15 @@ public class PostCommentController {
             userAccountPrincipal.toDTO());
         return new ResponseEntity<>(PostCommentResponse.from(postCommentDTO), HttpStatus.OK);
     }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Object> deletePostComment(
+        @IfLogin UserAccountPrincipal userAccountPrincipal,
+        @PathVariable Long commentId
+    ) {
+        postCommentService.deleteComment(commentId, userAccountPrincipal.toDTO());
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
 
 }

--- a/src/main/java/me/honki12345/hoonlog/controller/PostController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostController.java
@@ -3,6 +3,7 @@ package me.honki12345.hoonlog.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import me.honki12345.hoonlog.dto.PostDTO;
+import me.honki12345.hoonlog.dto.UserAccountDTO;
 import me.honki12345.hoonlog.dto.request.PostRequest;
 import me.honki12345.hoonlog.dto.response.PostResponse;
 import me.honki12345.hoonlog.dto.security.UserAccountPrincipal;
@@ -49,7 +50,8 @@ public class PostController {
         @IfLogin UserAccountPrincipal userAccountPrincipal,
         @Valid @RequestBody PostRequest postRequest) {
 
-        PostDTO postDTO = postService.addPost(postRequest, userAccountPrincipal);
+        PostDTO postDTO = postService.addPost(postRequest.toDTO(),
+            UserAccountDTO.from(userAccountPrincipal));
         return new ResponseEntity<>(PostResponse.from(postDTO), HttpStatus.CREATED);
     }
 
@@ -58,7 +60,8 @@ public class PostController {
         @IfLogin UserAccountPrincipal userAccountPrincipal,
         @PathVariable Long postId,
         @Valid @RequestBody PostRequest postRequest) {
-        PostDTO postDTO = postService.updatePost(postId, userAccountPrincipal, postRequest);
+        PostDTO postDTO = postService.updatePost(postId, UserAccountDTO.from(userAccountPrincipal),
+            postRequest.toDTO());
         return new ResponseEntity<>(PostResponse.from(postDTO), HttpStatus.OK);
     }
 
@@ -66,7 +69,7 @@ public class PostController {
     public ResponseEntity<Object> deletePost(
         @IfLogin UserAccountPrincipal userAccountPrincipal,
         @PathVariable Long postId) {
-        postService.deletePost(postId, userAccountPrincipal);
+        postService.deletePost(postId, UserAccountDTO.from(userAccountPrincipal));
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/controller/PostController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostController.java
@@ -3,7 +3,6 @@ package me.honki12345.hoonlog.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import me.honki12345.hoonlog.dto.PostDTO;
-import me.honki12345.hoonlog.dto.UserAccountDTO;
 import me.honki12345.hoonlog.dto.request.PostRequest;
 import me.honki12345.hoonlog.dto.response.PostResponse;
 import me.honki12345.hoonlog.dto.security.UserAccountPrincipal;
@@ -51,7 +50,7 @@ public class PostController {
         @Valid @RequestBody PostRequest postRequest) {
 
         PostDTO postDTO = postService.addPost(postRequest.toDTO(),
-            UserAccountDTO.from(userAccountPrincipal));
+            userAccountPrincipal.toDTO());
         return new ResponseEntity<>(PostResponse.from(postDTO), HttpStatus.CREATED);
     }
 
@@ -60,7 +59,7 @@ public class PostController {
         @IfLogin UserAccountPrincipal userAccountPrincipal,
         @PathVariable Long postId,
         @Valid @RequestBody PostRequest postRequest) {
-        PostDTO postDTO = postService.updatePost(postId, UserAccountDTO.from(userAccountPrincipal),
+        PostDTO postDTO = postService.updatePost(postId, userAccountPrincipal.toDTO(),
             postRequest.toDTO());
         return new ResponseEntity<>(PostResponse.from(postDTO), HttpStatus.OK);
     }
@@ -69,7 +68,7 @@ public class PostController {
     public ResponseEntity<Object> deletePost(
         @IfLogin UserAccountPrincipal userAccountPrincipal,
         @PathVariable Long postId) {
-        postService.deletePost(postId, UserAccountDTO.from(userAccountPrincipal));
+        postService.deletePost(postId, userAccountPrincipal.toDTO());
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/controller/UserAccountController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/UserAccountController.java
@@ -31,7 +31,7 @@ public class UserAccountController {
     @PostMapping
     public ResponseEntity<UserAccountResponse> addUserAccount(
         @Valid @RequestBody UserAccountAddRequest request) {
-        UserAccountDTO dto = userAccountService.saveUserAccount(request);
+        UserAccountDTO dto = userAccountService.saveUserAccount(request.toDTO());
         UserAccountResponse response = UserAccountResponse.from(dto);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
@@ -55,7 +55,7 @@ public class UserAccountController {
         if (userAccountPrincipal == null || !userAccountPrincipal.username().equals(username)) {
             throw new ForbiddenException(ErrorCode.FORBIDDEN);
         }
-        UserAccountDTO dto = userAccountService.modifyUserAccount(username, request);
+        UserAccountDTO dto = userAccountService.modifyUserAccount(username, request.toDTO());
         UserAccountResponse response = UserAccountResponse.from(dto);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/src/main/java/me/honki12345/hoonlog/domain/Post.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/Post.java
@@ -58,6 +58,10 @@ public class Post extends AuditingFields {
         return new Post(null, userAccount, title, content);
     }
 
+    public static Post of(Long id, UserAccount userAccount, String title, String content) {
+        return new Post(id, userAccount, title, content);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/me/honki12345/hoonlog/domain/Post.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/Post.java
@@ -1,5 +1,6 @@
 package me.honki12345.hoonlog.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -7,12 +8,16 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.honki12345.hoonlog.domain.vo.AuditingFields;
-import me.honki12345.hoonlog.dto.request.PostRequest;
+import me.honki12345.hoonlog.dto.PostDTO;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,11 +39,19 @@ public class Post extends AuditingFields {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @OrderBy("createdAt DESC")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private final Set<PostComment> postComments = new LinkedHashSet<>();
+
     private Post(Long id, UserAccount userAccount, String title, String content) {
         this.id = id;
         this.userAccount = userAccount;
         this.title = title;
         this.content = content;
+    }
+
+    public static Post of(String title, String content) {
+        return Post.of(null, title, content);
     }
 
     public static Post of(UserAccount userAccount, String title, String content) {
@@ -61,8 +74,13 @@ public class Post extends AuditingFields {
         return Objects.hash(id);
     }
 
-    public void update(PostRequest postRequest) {
-        this.title = postRequest.title();
-        this.content = postRequest.content();
+    public void update(PostDTO dto) {
+        this.title = dto.title();
+        this.content = dto.content();
+    }
+
+    public Post addUserAccount(UserAccount userAccount) {
+        this.userAccount = userAccount;
+        return this;
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/domain/PostComment.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/PostComment.java
@@ -53,6 +53,12 @@ public class PostComment extends AuditingFields {
         return this;
     }
 
+    public void update(String content) {
+        if (content != null) {
+            this.content = content;
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/me/honki12345/hoonlog/domain/PostComment.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/PostComment.java
@@ -1,5 +1,71 @@
 package me.honki12345.hoonlog.domain;
 
-public class PostComment {
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.honki12345.hoonlog.domain.vo.AuditingFields;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class PostComment extends AuditingFields {
+    @Id
+    @Column(name = "comment_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Post post;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private UserAccount userAccount;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+    private PostComment(Long id, Post post, UserAccount userAccount, String content) {
+        this.id = id;
+        this.post = post;
+        this.userAccount = userAccount;
+        this.content = content;
+    }
+
+    public static PostComment of(Long id, Post post, UserAccount userAccount, String content) {
+        return new PostComment(id, post, userAccount, content);
+    }
+
+    public PostComment addPost(Post post) {
+        this.post = post;
+        return this;
+    }
+
+    public PostComment addUserAccount(UserAccount userAccount) {
+        this.userAccount = userAccount;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PostComment that)) {
+            return false;
+        }
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/src/main/java/me/honki12345/hoonlog/domain/UserAccount.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/UserAccount.java
@@ -70,10 +70,6 @@ public class UserAccount {
         this.createdAt = createdAt;
     }
 
-    public void addRole(Role role) {
-        roles.add(role);
-    }
-
     public static UserAccount of(String username, String userPassword, String email,
         Profile profile) {
         return new UserAccount(null, username, userPassword, email, profile, null);

--- a/src/main/java/me/honki12345/hoonlog/dto/PostCommentDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/PostCommentDTO.java
@@ -1,0 +1,36 @@
+package me.honki12345.hoonlog.dto;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import me.honki12345.hoonlog.domain.Post;
+import me.honki12345.hoonlog.domain.PostComment;
+import me.honki12345.hoonlog.domain.UserAccount;
+
+public record PostCommentDTO(
+    Long id,
+    PostDTO postDTO,
+    UserAccountDTO userAccountDTO,
+    String content,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime modifiedAt
+) {
+
+    public static PostCommentDTO of(String content) {
+        return new PostCommentDTO(null, null, null, content, null, null, null);
+    }
+
+    public static PostCommentDTO from(PostComment entity) {
+        return new PostCommentDTO(entity.getId(), PostDTO.from(entity.getPost()),
+            UserAccountDTO.from(entity.getUserAccount()),
+            entity.getContent(), entity.getCreatedAt(), entity.getCreatedBy(),
+            entity.getModifiedAt());
+    }
+
+    public PostComment toEntity() {
+        Post post = Optional.ofNullable(postDTO).map(PostDTO::toEntity).orElse(null);
+        UserAccount userAccount = Optional.ofNullable(userAccountDTO).map(UserAccountDTO::toEntity)
+            .orElse(null);
+        return PostComment.of(id, post, userAccount, content);
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/dto/PostDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/PostDTO.java
@@ -27,8 +27,15 @@ public record PostDTO(
         );
     }
 
+    public static PostDTO of(String title, String content) {
+        return PostDTO.of(null, title, content);
+    }
+
     public static PostDTO of(UserAccountDTO userAccountDTO, String title, String content) {
         return new PostDTO(null, userAccountDTO, title, content, null, null, null, null);
     }
 
+    public Post toEntity() {
+        return Post.of(title, content);
+    }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/PostDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/PostDTO.java
@@ -1,7 +1,9 @@
 package me.honki12345.hoonlog.dto;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import me.honki12345.hoonlog.domain.Post;
+import me.honki12345.hoonlog.domain.UserAccount;
 
 public record PostDTO(
     Long id,
@@ -35,7 +37,13 @@ public record PostDTO(
         return new PostDTO(null, userAccountDTO, title, content, null, null, null, null);
     }
 
+    public static PostDTO of(Long postId) {
+        return new PostDTO(postId, null, null, null, null, null, null, null);
+    }
+
     public Post toEntity() {
-        return Post.of(title, content);
+        UserAccount userAccount = Optional.ofNullable(userAccountDTO).map(UserAccountDTO::toEntity)
+            .orElse(null);
+        return Post.of(id, userAccount, title, content);
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/ProfileDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/ProfileDTO.java
@@ -9,8 +9,8 @@ public record ProfileDTO(
     String blogShortBio
 ) {
 
-    public static Profile toVO(ProfileDTO dto) {
-        return Profile.of(dto.blogName(), dto.blogShortBio());
+    public Profile toVO() {
+        return Profile.of(blogName, blogShortBio);
     }
 
     public static ProfileDTO from(Profile profile) {

--- a/src/main/java/me/honki12345/hoonlog/dto/UserAccountDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/UserAccountDTO.java
@@ -19,17 +19,6 @@ public record UserAccountDTO(
     Set<Role> roles
 ) {
 
-    public static UserAccountDTO from(UserAccount entity) {
-        return new UserAccountDTO(
-            entity.getId(),
-            entity.getUsername(),
-            entity.getUserPassword(),
-            entity.getEmail(),
-            ProfileDTO.from(entity.getProfile()),
-            entity.getCreatedAt(),
-            entity.getRoles()
-        );
-    }
 
     public UserAccountDTO changePassword(String newUserPassword) {
         return new UserAccountDTO(this.id, this.username, newUserPassword, this.email,
@@ -60,16 +49,16 @@ public record UserAccountDTO(
         return new UserAccountDTO(userId, username, null, null, null, null, roleSet);
     }
 
-    public static UserAccountDTO from(UserAccountPrincipal userAccountPrincipal) {
-        return UserAccountDTO.of(userAccountPrincipal.userId(), userAccountPrincipal.username(),
-            userAccountPrincipal.roles());
-    }
-
-    public UserAccountPrincipal toPrincipal() {
-        return new UserAccountPrincipal(
-            id(),
-            username(),
-            roles().stream().map(Role::getName).collect(Collectors.toList()));
+    public static UserAccountDTO from(UserAccount entity) {
+        return new UserAccountDTO(
+            entity.getId(),
+            entity.getUsername(),
+            entity.getUserPassword(),
+            entity.getEmail(),
+            ProfileDTO.from(entity.getProfile()),
+            entity.getCreatedAt(),
+            entity.getRoles()
+        );
     }
 
     public UserAccount toEntity() {

--- a/src/main/java/me/honki12345/hoonlog/dto/UserAccountDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/UserAccountDTO.java
@@ -1,6 +1,7 @@
 package me.honki12345.hoonlog.dto;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -30,9 +31,38 @@ public record UserAccountDTO(
         );
     }
 
+    public UserAccountDTO changePassword(String newUserPassword) {
+        return new UserAccountDTO(this.id, this.username, newUserPassword, this.email,
+            this.profileDTO, this.createdAt, this.roles);
+    }
+
+    public UserAccountDTO addRole(Role role) {
+        this.roles.add(role);
+        return this;
+    }
+
+    public static UserAccountDTO of(String username, String password) {
+        return new UserAccountDTO(null, username, password, null, null, null, null);
+    }
+
+    public static UserAccountDTO of(ProfileDTO profile) {
+        return new UserAccountDTO(null, null, null, null, profile, null, null);
+    }
+
+    public static UserAccountDTO of(Long userId, String username, String userPassword, String email,
+        ProfileDTO profileDTO) {
+        return new UserAccountDTO(userId, username, userPassword, email, profileDTO, null,
+            new HashSet<>());
+    }
+
     public static UserAccountDTO of(Long userId, String username, List<String> roles) {
         Set<Role> roleSet = roles.stream().map(Role::of).collect(Collectors.toSet());
         return new UserAccountDTO(userId, username, null, null, null, null, roleSet);
+    }
+
+    public static UserAccountDTO from(UserAccountPrincipal userAccountPrincipal) {
+        return UserAccountDTO.of(userAccountPrincipal.userId(), userAccountPrincipal.username(),
+            userAccountPrincipal.roles());
     }
 
     public UserAccountPrincipal toPrincipal() {
@@ -40,5 +70,9 @@ public record UserAccountDTO(
             id(),
             username(),
             roles().stream().map(Role::getName).collect(Collectors.toList()));
+    }
+
+    public UserAccount toEntity() {
+        return UserAccount.of(username, userPassword, email, profileDTO.toVO());
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/request/LoginRequest.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/request/LoginRequest.java
@@ -2,6 +2,7 @@ package me.honki12345.hoonlog.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import me.honki12345.hoonlog.dto.UserAccountDTO;
 
 public record LoginRequest(
     @NotNull(message = "아이디를 입력해주세요")
@@ -11,4 +12,7 @@ public record LoginRequest(
     String password
 ) {
 
+    public UserAccountDTO toDTO() {
+        return UserAccountDTO.of(username, password);
+    }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/request/PostCommentRequest.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/request/PostCommentRequest.java
@@ -10,6 +10,10 @@ public record PostCommentRequest(
     String content
 ) {
 
+    public static PostCommentRequest of(String content) {
+        return new PostCommentRequest(null, content);
+    }
+
     public PostCommentDTO toDTO() {
         return PostCommentDTO.of(content);
     }

--- a/src/main/java/me/honki12345/hoonlog/dto/request/PostCommentRequest.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/request/PostCommentRequest.java
@@ -1,0 +1,16 @@
+package me.honki12345.hoonlog.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import me.honki12345.hoonlog.dto.PostCommentDTO;
+
+public record PostCommentRequest(
+    @NotNull(message = "잘못된 입력입니다")
+    Long postId,
+    @NotNull(message = "내용을 입력해주세요")
+    String content
+) {
+
+    public PostCommentDTO toDTO() {
+        return PostCommentDTO.of(content);
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/dto/request/PostRequest.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/request/PostRequest.java
@@ -1,8 +1,7 @@
 package me.honki12345.hoonlog.dto.request;
 
 import jakarta.validation.constraints.NotNull;
-import me.honki12345.hoonlog.domain.Post;
-import me.honki12345.hoonlog.domain.UserAccount;
+import me.honki12345.hoonlog.dto.PostDTO;
 
 public record PostRequest(
     @NotNull(message = "제목을 입력해주세요")
@@ -10,7 +9,7 @@ public record PostRequest(
     String content
 ) {
 
-    public Post toEntityWithUserAccount(UserAccount userAccount) {
-        return Post.of(userAccount, title, content);
+    public PostDTO toDTO() {
+        return PostDTO.of(title, content);
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/request/UserAccountAddRequest.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/request/UserAccountAddRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Size;
 import me.honki12345.hoonlog.domain.Role;
 import me.honki12345.hoonlog.domain.UserAccount;
 import me.honki12345.hoonlog.dto.ProfileDTO;
+import me.honki12345.hoonlog.dto.UserAccountDTO;
 
 public record UserAccountAddRequest(
     @NotNull(message = "아이디를 입력해주세요")
@@ -23,7 +24,11 @@ public record UserAccountAddRequest(
     ProfileDTO profile
 ) {
 
+    public UserAccountDTO toDTO() {
+        return UserAccountDTO.of(null, username, userPassword, email, profile);
+    }
+
     public UserAccount toEntity(String encodedPwd) {
-        return UserAccount.of(username, encodedPwd, email, ProfileDTO.toVO(profile));
+        return UserAccount.of(username, encodedPwd, email, profile.toVO());
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/request/UserAccountModifyRequest.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/request/UserAccountModifyRequest.java
@@ -3,6 +3,7 @@ package me.honki12345.hoonlog.dto.request;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import me.honki12345.hoonlog.dto.ProfileDTO;
+import me.honki12345.hoonlog.dto.UserAccountDTO;
 
 public record UserAccountModifyRequest(
     @Valid
@@ -10,4 +11,7 @@ public record UserAccountModifyRequest(
     ProfileDTO profile
 ) {
 
+    public UserAccountDTO toDTO() {
+        return UserAccountDTO.of(profile);
+    }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/response/PostCommentResponse.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/response/PostCommentResponse.java
@@ -1,0 +1,19 @@
+package me.honki12345.hoonlog.dto.response;
+
+import java.time.LocalDateTime;
+import me.honki12345.hoonlog.dto.PostCommentDTO;
+
+public record PostCommentResponse(
+    Long id,
+    String content,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime modifiedAt
+
+) {
+
+    public static PostCommentResponse from(PostCommentDTO dto) {
+        return new PostCommentResponse(dto.id(), dto.content(), dto.createdAt(), dto.createdBy(),
+            dto.modifiedAt());
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/dto/security/UserAccountPrincipal.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/security/UserAccountPrincipal.java
@@ -2,6 +2,9 @@ package me.honki12345.hoonlog.dto.security;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import me.honki12345.hoonlog.domain.Role;
+import me.honki12345.hoonlog.dto.UserAccountDTO;
 
 public record UserAccountPrincipal(
     Long userId,
@@ -15,5 +18,17 @@ public record UserAccountPrincipal(
 
     public static UserAccountPrincipal of(Long userId, String username) {
         return new UserAccountPrincipal(userId, username, new ArrayList<>());
+    }
+
+
+    public UserAccountDTO toDTO() {
+        return UserAccountDTO.of(userId, username, roles);
+    }
+
+    public static UserAccountPrincipal from(UserAccountDTO dto) {
+        List<String> roles = dto.roles().stream().map(
+            Role::getName).collect(
+            Collectors.toList());
+        return new UserAccountPrincipal(dto.id(), dto.username(), roles);
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/error/ErrorCode.java
+++ b/src/main/java/me/honki12345/hoonlog/error/ErrorCode.java
@@ -24,7 +24,9 @@ public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN3", "토큰 유효기간이 지났습니다"),
     TOKEN_UNSUPPORTED(HttpStatus.BAD_REQUEST, "TOKEN4", "지원하지 않는 토큰입니다"),
 
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST1", "게시글을 찾을 수 없습니다");
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST1", "게시글을 찾을 수 없습니다"),
+
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT1", "댓글을 찾을 수 없습니다");
 
     private final String message;
     private final String code;

--- a/src/main/java/me/honki12345/hoonlog/error/GlobalExceptionHandler.java
+++ b/src/main/java/me/honki12345/hoonlog/error/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import me.honki12345.hoonlog.error.exception.CustomBaseException;
 import me.honki12345.hoonlog.error.exception.domain.DuplicateUserAccountException;
 import me.honki12345.hoonlog.error.exception.ForbiddenException;
+import me.honki12345.hoonlog.error.exception.domain.PostCommentNotFoundException;
 import me.honki12345.hoonlog.error.exception.domain.PostNotFoundException;
 import me.honki12345.hoonlog.error.exception.security.JwtException;
 import me.honki12345.hoonlog.error.exception.security.LoginErrorException;
@@ -79,6 +80,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(PostNotFoundException.class)
     public ResponseEntity<ErrorResponse> postNotFoundException(PostNotFoundException exception) {
+        return createResponseEntityByException(exception);
+    }
+
+    @ExceptionHandler(PostCommentNotFoundException.class)
+    public ResponseEntity<ErrorResponse> postCommentNotFoundException(
+        PostCommentNotFoundException exception) {
         return createResponseEntityByException(exception);
     }
 

--- a/src/main/java/me/honki12345/hoonlog/error/exception/domain/PostCommentNotFoundException.java
+++ b/src/main/java/me/honki12345/hoonlog/error/exception/domain/PostCommentNotFoundException.java
@@ -1,0 +1,11 @@
+package me.honki12345.hoonlog.error.exception.domain;
+
+import me.honki12345.hoonlog.error.ErrorCode;
+import me.honki12345.hoonlog.error.exception.CustomBaseException;
+
+public class PostCommentNotFoundException extends CustomBaseException {
+
+    public PostCommentNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/repository/PostCommentRepository.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/PostCommentRepository.java
@@ -1,0 +1,8 @@
+package me.honki12345.hoonlog.repository;
+
+import me.honki12345.hoonlog.domain.PostComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
+
+}

--- a/src/main/java/me/honki12345/hoonlog/service/PostCommentService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/PostCommentService.java
@@ -49,4 +49,14 @@ public class PostCommentService {
         postComment.update(postCommentDTO.content());
         return PostCommentDTO.from(postComment);
     }
+
+    public void deleteComment(Long commentId, UserAccountDTO userAccountDTO) {
+        PostComment postComment = postCommentRepository.findById(commentId)
+            .orElseThrow(() -> new PostCommentNotFoundException(
+                ErrorCode.COMMENT_NOT_FOUND));
+        if (!postComment.getUserAccount().getId().equals(userAccountDTO.id())) {
+            throw new ForbiddenException(ErrorCode.FORBIDDEN);
+        }
+        postCommentRepository.delete(postComment);
+    }
 }

--- a/src/main/java/me/honki12345/hoonlog/service/PostCommentService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/PostCommentService.java
@@ -1,0 +1,38 @@
+package me.honki12345.hoonlog.service;
+
+import lombok.RequiredArgsConstructor;
+import me.honki12345.hoonlog.domain.Post;
+import me.honki12345.hoonlog.domain.PostComment;
+import me.honki12345.hoonlog.domain.UserAccount;
+import me.honki12345.hoonlog.dto.PostCommentDTO;
+import me.honki12345.hoonlog.dto.UserAccountDTO;
+import me.honki12345.hoonlog.error.ErrorCode;
+import me.honki12345.hoonlog.error.exception.domain.PostNotFoundException;
+import me.honki12345.hoonlog.error.exception.domain.UserAccountNotFoundException;
+import me.honki12345.hoonlog.repository.PostCommentRepository;
+import me.honki12345.hoonlog.repository.PostRepository;
+import me.honki12345.hoonlog.repository.UserAccountRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class PostCommentService {
+
+    private final PostCommentRepository postCommentRepository;
+    private final UserAccountRepository userAccountRepository;
+    private final PostRepository postRepository;
+
+    public PostCommentDTO addPostComment(PostCommentDTO postCommentDTO,
+        Long postId, UserAccountDTO userAccountDTO) {
+        PostComment postComment = postCommentDTO.toEntity();
+        Post post = postRepository.findById(postId).orElseThrow(() -> new PostNotFoundException(
+            ErrorCode.POST_NOT_FOUND));
+        UserAccount userAccount = userAccountRepository.findById(userAccountDTO.id())
+            .orElseThrow(() -> new UserAccountNotFoundException(
+                ErrorCode.USER_ACCOUNT_NOT_FOUND));
+        postComment = postComment.addPost(post).addUserAccount(userAccount);
+        return PostCommentDTO.from(postCommentRepository.save(postComment));
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/service/PostCommentService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/PostCommentService.java
@@ -7,6 +7,8 @@ import me.honki12345.hoonlog.domain.UserAccount;
 import me.honki12345.hoonlog.dto.PostCommentDTO;
 import me.honki12345.hoonlog.dto.UserAccountDTO;
 import me.honki12345.hoonlog.error.ErrorCode;
+import me.honki12345.hoonlog.error.exception.ForbiddenException;
+import me.honki12345.hoonlog.error.exception.domain.PostCommentNotFoundException;
 import me.honki12345.hoonlog.error.exception.domain.PostNotFoundException;
 import me.honki12345.hoonlog.error.exception.domain.UserAccountNotFoundException;
 import me.honki12345.hoonlog.repository.PostCommentRepository;
@@ -34,5 +36,17 @@ public class PostCommentService {
                 ErrorCode.USER_ACCOUNT_NOT_FOUND));
         postComment = postComment.addPost(post).addUserAccount(userAccount);
         return PostCommentDTO.from(postCommentRepository.save(postComment));
+    }
+
+    public PostCommentDTO modifyComment(PostCommentDTO postCommentDTO, Long commentId,
+        UserAccountDTO dto) {
+        PostComment postComment = postCommentRepository.findById(commentId)
+            .orElseThrow(() -> new PostCommentNotFoundException(
+                ErrorCode.COMMENT_NOT_FOUND));
+        if (!postComment.getUserAccount().getId().equals(dto.id())) {
+            throw new ForbiddenException(ErrorCode.FORBIDDEN);
+        }
+        postComment.update(postCommentDTO.content());
+        return PostCommentDTO.from(postComment);
     }
 }

--- a/src/test/java/me/honki12345/hoonlog/controller/AuthControllerTest.java
+++ b/src/test/java/me/honki12345/hoonlog/controller/AuthControllerTest.java
@@ -55,7 +55,7 @@ class AuthControllerTest {
 
     @AfterEach
     void tearDown() {
-        userAccountRepository.deleteAllInBatch();
+        testUtil.deleteAllInBatchInAllRepository();
     }
 
     @DisplayName("[로그인/성공]로그인에 성공한다")

--- a/src/test/java/me/honki12345/hoonlog/controller/PostCommentControllerTest.java
+++ b/src/test/java/me/honki12345/hoonlog/controller/PostCommentControllerTest.java
@@ -1,0 +1,98 @@
+package me.honki12345.hoonlog.controller;
+
+import static io.restassured.RestAssured.given;
+import static me.honki12345.hoonlog.util.TestUtil.TEST_COMMENT_CONTENT;
+import static me.honki12345.hoonlog.util.TestUtil.TEST_USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import me.honki12345.hoonlog.domain.Post;
+import me.honki12345.hoonlog.dto.TokenDTO;
+import me.honki12345.hoonlog.dto.request.PostCommentRequest;
+import me.honki12345.hoonlog.repository.PostRepository;
+import me.honki12345.hoonlog.repository.UserAccountRepository;
+import me.honki12345.hoonlog.service.AuthService;
+import me.honki12345.hoonlog.service.PostService;
+import me.honki12345.hoonlog.service.UserAccountService;
+import me.honki12345.hoonlog.util.TestUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+
+@DisplayName("E2E PostCommentController 컨트롤러 테스트")
+@Import({TestUtil.class})
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PostCommentControllerTest {
+
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    TestUtil testUtil;
+    @Autowired
+    AuditorAware<String> auditorAwareForTest;
+
+    @Autowired
+    PostController postController;
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    UserAccountRepository userAccountRepository;
+    @Autowired
+    UserAccountService userAccountService;
+    @Autowired
+    AuthService authService;
+    @Autowired
+    PostService postService;
+
+    @LocalServerPort
+    private int port;
+
+    @AfterEach
+    void tearDown() {
+        testUtil.deleteAllInBatchInAllRepository();
+    }
+
+    @DisplayName("댓글 생성에 성공한다.")
+    @Test
+    void givenPostCommentInfo_whenAddingPostComment_thenReturnsSavedPostCommentInfo()
+        throws JsonProcessingException {
+        // given
+        TokenDTO tokenDTO = testUtil.createTokensAfterSavingTestUser();
+        Post post = testUtil.createPostWithTestUser();
+        PostCommentRequest postCommentRequest = new PostCommentRequest(post.getId(),
+            TestUtil.TEST_COMMENT_CONTENT);
+
+        // when
+        ExtractableResponse<Response> extract =
+            given().log().all()
+                .header("Authorization", "Bearer " + tokenDTO.accessToken())
+                .port(port)
+                .body(objectMapper.writeValueAsString(postCommentRequest))
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/api/v1/comments")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(
+            () -> assertThat(extract.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+            () -> assertThat(extract.jsonPath().getString("createdBy")).isEqualTo(TEST_USERNAME),
+            () -> assertThat(extract.jsonPath().getString("content")).isEqualTo(TEST_COMMENT_CONTENT)
+        );
+
+    }
+}

--- a/src/test/java/me/honki12345/hoonlog/controller/PostControllerTest.java
+++ b/src/test/java/me/honki12345/hoonlog/controller/PostControllerTest.java
@@ -238,7 +238,7 @@ class PostControllerTest {
         for (int i = 0; i < 10; i++) {
             PostRequest postRequest = new PostRequest("title" + i, "content" + i);
             userAccountRepository.findByUsername(TEST_USERNAME).ifPresent(userAccount ->
-                postRepository.save(postRequest.toEntityWithUserAccount(userAccount)));
+                postRepository.save(postRequest.toDTO().toEntity().addUserAccount(userAccount)));
         }
     }
 
@@ -248,6 +248,6 @@ class PostControllerTest {
         PostRequest postRequest = new PostRequest(title, content);
         Optional<UserAccount> optionalUserAccount = userAccountRepository.findByUsername(TEST_USERNAME);
         return optionalUserAccount.map(userAccount -> postRepository.save(
-            postRequest.toEntityWithUserAccount(userAccount))).orElse(null);
+            postRequest.toDTO().toEntity().addUserAccount(userAccount))).orElse(null);
     }
 }

--- a/src/test/java/me/honki12345/hoonlog/controller/PostControllerTest.java
+++ b/src/test/java/me/honki12345/hoonlog/controller/PostControllerTest.java
@@ -75,7 +75,7 @@ class PostControllerTest {
         String username = "fpg123";
         String title = "title";
         String content = "content";
-        TokenDTO tokenDTO = testUtil.createTokensAfterSaving(username, "12345678");
+        TokenDTO tokenDTO = testUtil.createTokensAfterSavingTestUser(username, "12345678");
         PostRequest postRequest = new PostRequest(title, content);
 
         ExtractableResponse<Response> extract =
@@ -178,7 +178,7 @@ class PostControllerTest {
     void givenUpdatingInfo_whenUpdatingPost_thenReturnsUpdatedPostInfo()
         throws JsonProcessingException {
         // given // when
-        TokenDTO tokenDTO = testUtil.createTokensAfterSaving();
+        TokenDTO tokenDTO = testUtil.createTokensAfterSavingTestUser();
         Post createdPost = testUtil.createPostWithTestUser("title", "content");
         String newTitle = "newTitle";
         String newContent = "newContent";
@@ -211,7 +211,7 @@ class PostControllerTest {
     void givenPostId_whenDeletingPost_thenReturnsOK()
         throws JsonProcessingException {
         // given // when
-        TokenDTO tokenDTO = testUtil.createTokensAfterSaving();
+        TokenDTO tokenDTO = testUtil.createTokensAfterSavingTestUser();
         Post createdPost = testUtil.createPostWithTestUser("title", "content");
 
         ExtractableResponse<Response> extract =
@@ -234,7 +234,7 @@ class PostControllerTest {
 
     @WithMockCustomUser
     private void createPostsWithMockCustomer() {
-        testUtil.createTokensAfterSaving(TEST_USERNAME, TEST_PASSWORD);
+        testUtil.createTokensAfterSavingTestUser(TEST_USERNAME, TEST_PASSWORD);
         for (int i = 0; i < 10; i++) {
             PostRequest postRequest = new PostRequest("title" + i, "content" + i);
             userAccountRepository.findByUsername(TEST_USERNAME).ifPresent(userAccount ->
@@ -244,7 +244,7 @@ class PostControllerTest {
 
     @WithMockCustomUser
     private Post createPostWithMockCustomer(String title, String content) {
-        testUtil.createTokensAfterSaving(TEST_USERNAME, TEST_PASSWORD);
+        testUtil.createTokensAfterSavingTestUser(TEST_USERNAME, TEST_PASSWORD);
         PostRequest postRequest = new PostRequest(title, content);
         Optional<UserAccount> optionalUserAccount = userAccountRepository.findByUsername(TEST_USERNAME);
         return optionalUserAccount.map(userAccount -> postRepository.save(

--- a/src/test/java/me/honki12345/hoonlog/controller/UserAccountControllerTest.java
+++ b/src/test/java/me/honki12345/hoonlog/controller/UserAccountControllerTest.java
@@ -125,7 +125,7 @@ class UserAccountControllerTest {
         ProfileDTO profileDTO = new ProfileDTO("blogName", null);
         UserAccountAddRequest request = new UserAccountAddRequest(
             "fpg123", "12345678", "fpg123@mail.com", profileDTO);
-        userAccountService.saveUserAccount(request);
+        userAccountService.saveUserAccount(request.toDTO());
 
         RequestSpecification requestSpecification = RestAssured
             .given().log().all()

--- a/src/test/java/me/honki12345/hoonlog/controller/UserAccountControllerTest.java
+++ b/src/test/java/me/honki12345/hoonlog/controller/UserAccountControllerTest.java
@@ -55,7 +55,7 @@ class UserAccountControllerTest {
 
     @AfterEach
     void tearDown() {
-        userAccountRepository.deleteAllInBatch();
+        testUtil.deleteAllInBatchInAllRepository();
     }
 
     @DisplayName("[생성/성공]회원가입을 성공한다")

--- a/src/test/java/me/honki12345/hoonlog/service/AuthServiceTest.java
+++ b/src/test/java/me/honki12345/hoonlog/service/AuthServiceTest.java
@@ -10,6 +10,7 @@ import me.honki12345.hoonlog.error.exception.security.LogoutErrorException;
 import me.honki12345.hoonlog.repository.RefreshTokenRepository;
 import me.honki12345.hoonlog.repository.UserAccountRepository;
 import me.honki12345.hoonlog.security.jwt.util.JwtTokenizer;
+import me.honki12345.hoonlog.util.TestUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,12 +31,15 @@ class AuthServiceTest {
     UserAccountRepository userAccountRepository;
     @Autowired
     RefreshTokenRepository refreshTokenRepository;
+
     @Autowired
     JwtTokenizer jwtTokenizer;
+    @Autowired
+    TestUtil testUtil;
 
     @AfterEach
     void tearDown() {
-        refreshTokenRepository.deleteAllInBatch();
+        testUtil.deleteAllInBatchInAllRepository();
     }
 
     @DisplayName("[로그인/성공]유저 정보를 입력시, 토큰생성을 성공한다.")

--- a/src/test/java/me/honki12345/hoonlog/service/AuthServiceTest.java
+++ b/src/test/java/me/honki12345/hoonlog/service/AuthServiceTest.java
@@ -1,7 +1,5 @@
 package me.honki12345.hoonlog.service;
 
-import java.util.Set;
-import me.honki12345.hoonlog.domain.Role;
 import me.honki12345.hoonlog.domain.UserAccount;
 import me.honki12345.hoonlog.domain.vo.Profile;
 import me.honki12345.hoonlog.dto.TokenDTO;
@@ -16,11 +14,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("AuthService 애플리케이션 통합테스트")
+@Import({TestUtil.class})
 @ActiveProfiles("test")
 @SpringBootTest
 class AuthServiceTest {
@@ -46,7 +46,7 @@ class AuthServiceTest {
     @Test
     void givenUserInfo_whenLogin_thenReturnsTokens() {
         // given
-        UserAccountDTO userAccountDTO = createUserAccountDTO();
+        UserAccountDTO userAccountDTO = testUtil.saveTestUser();
 
         // when
         TokenDTO tokenDTO = authService.createTokens(userAccountDTO);
@@ -57,15 +57,15 @@ class AuthServiceTest {
 
         // then
         assertThat(refreshTokenRepository.existsByToken(refreshToken)).isTrue();
-        assertThat(userIdFromAccessToken).isEqualTo(1L);
-        assertThat(userIdFromRefreshToken).isEqualTo(1L);
+        assertThat(userIdFromAccessToken).isEqualTo(userAccountDTO.id());
+        assertThat(userIdFromRefreshToken).isEqualTo(userAccountDTO.id());
     }
 
     @DisplayName("[로그아웃/성공]저장된 리프레쉬 토큰을 입력하고, 로그아웃을 하면, 토큰을 삭제한다.")
     @Test
     void givenSavedRefreshToken_whenLogout_thenDeletingSavedRefreshToken() {
         // given
-        UserAccountDTO userAccountDTO = createUserAccountDTO();
+        UserAccountDTO userAccountDTO = testUtil.saveTestUser();
         TokenDTO tokenDTO = authService.createTokens(userAccountDTO);
 
         // when
@@ -100,10 +100,4 @@ class AuthServiceTest {
             userAccount.getId());
     }
 
-    private static UserAccountDTO createUserAccountDTO() {
-        Set<Role> roles = Set.of(Role.of("ROLE_USER"));
-        UserAccountDTO userAccountDTO = new UserAccountDTO(1L, "username", "password", null, null,
-            null, roles);
-        return userAccountDTO;
-    }
 }

--- a/src/test/java/me/honki12345/hoonlog/service/PostCommentServiceTest.java
+++ b/src/test/java/me/honki12345/hoonlog/service/PostCommentServiceTest.java
@@ -1,0 +1,63 @@
+package me.honki12345.hoonlog.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.honki12345.hoonlog.domain.Post;
+import me.honki12345.hoonlog.dto.PostCommentDTO;
+import me.honki12345.hoonlog.dto.UserAccountDTO;
+import me.honki12345.hoonlog.dto.request.PostCommentRequest;
+import me.honki12345.hoonlog.repository.PostRepository;
+import me.honki12345.hoonlog.repository.UserAccountRepository;
+import me.honki12345.hoonlog.util.TestUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DisplayName("PostCommentService 애플리케이션 통합테스트")
+@Import({TestUtil.class})
+@ActiveProfiles("test")
+@SpringBootTest
+class PostCommentServiceTest {
+
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    TestUtil testUtil;
+
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    UserAccountRepository userAccountRepository;
+    @Autowired
+    PostCommentService postCommentService;
+
+    @AfterEach
+    void tearDown() {
+        testUtil.deleteAllInBatchInAllRepository();
+    }
+
+    @DisplayName("댓글 생성에 성공한다.")
+    @Test
+    void givenCommentInfoWithPostIdAndUserInfo_whenAddingComment_thenReturnsSavedPostComment() {
+        // given
+        UserAccountDTO userAccountDTO = testUtil.saveTestUser();
+        Post post = testUtil.createPostWithTestUser();
+        PostCommentRequest postCommentRequest = new PostCommentRequest(post.getId(),
+            TestUtil.TEST_COMMENT_CONTENT);
+
+        // when
+        PostCommentDTO postCommentDTO = postCommentService.addPostComment(
+            postCommentRequest.toDTO(), post.getId(), userAccountDTO);
+
+        // then
+        assertThat(postCommentDTO.postDTO().id()).isEqualTo(post.getId());
+        assertThat(postCommentDTO.createdBy()).isEqualTo(userAccountDTO.username());
+        assertThat(postCommentDTO.content()).isEqualTo(TestUtil.TEST_COMMENT_CONTENT);
+    }
+
+}

--- a/src/test/java/me/honki12345/hoonlog/service/PostCommentServiceTest.java
+++ b/src/test/java/me/honki12345/hoonlog/service/PostCommentServiceTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import me.honki12345.hoonlog.domain.Post;
+import me.honki12345.hoonlog.domain.PostComment;
 import me.honki12345.hoonlog.dto.PostCommentDTO;
 import me.honki12345.hoonlog.dto.UserAccountDTO;
 import me.honki12345.hoonlog.dto.request.PostCommentRequest;
+import me.honki12345.hoonlog.repository.PostCommentRepository;
 import me.honki12345.hoonlog.repository.PostRepository;
 import me.honki12345.hoonlog.repository.UserAccountRepository;
 import me.honki12345.hoonlog.util.TestUtil;
@@ -34,6 +36,8 @@ class PostCommentServiceTest {
     @Autowired
     UserAccountRepository userAccountRepository;
     @Autowired
+    PostCommentRepository postCommentRepository;
+    @Autowired
     PostCommentService postCommentService;
 
     @AfterEach
@@ -60,4 +64,39 @@ class PostCommentServiceTest {
         assertThat(postCommentDTO.content()).isEqualTo(TestUtil.TEST_COMMENT_CONTENT);
     }
 
+    @DisplayName("댓글 수정에 성공한다.")
+    @Test
+    void givenCommentInfoWithPostIdAndUserInfo_whenUpdatingComment_thenReturnsUpdatedPostComment() {
+        // given
+        UserAccountDTO userAccountDTO = testUtil.saveTestUser();
+        Post post = testUtil.createPostWithTestUser();
+        PostComment savedPostComment = testUtil.createCommentWithTestUser(post.getId());
+        String updatedContent = "updatedContent";
+        PostCommentRequest updateRequest = new PostCommentRequest(post.getId(), updatedContent);
+
+        // when
+        PostCommentDTO savedPostCommentDTO = postCommentService.modifyComment(updateRequest.toDTO(),
+            savedPostComment.getId(),
+            userAccountDTO);
+
+        // then
+        assertThat(savedPostCommentDTO.postDTO().id()).isEqualTo(post.getId());
+        assertThat(savedPostCommentDTO.createdBy()).isEqualTo(userAccountDTO.username());
+        assertThat(savedPostCommentDTO.content()).isEqualTo(updatedContent);
+    }
+
+    @DisplayName("댓글 삭제에 성공한다.")
+    @Test
+    void givenCommentIdWithUserInfo_whenDeletingComment_thenReturnsNothing() {
+        // given
+        UserAccountDTO userAccountDTO = testUtil.saveTestUser();
+        Post post = testUtil.createPostWithTestUser();
+        PostComment savedPostComment = testUtil.createCommentWithTestUser(post.getId());
+
+        // when
+        postCommentService.deleteComment(savedPostComment.getId(), userAccountDTO);
+
+        // then
+        assertThat(postCommentRepository.existsById(savedPostComment.getId())).isFalse();
+    }
 }

--- a/src/test/java/me/honki12345/hoonlog/service/PostServiceTest.java
+++ b/src/test/java/me/honki12345/hoonlog/service/PostServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-@DisplayName("AuthService 애플리케이션 통합테스트")
+@DisplayName("PostService 애플리케이션 통합테스트")
 @Import({TestUtil.class})
 @ActiveProfiles("test")
 @SpringBootTest
@@ -32,6 +32,7 @@ class PostServiceTest {
     ObjectMapper objectMapper;
     @Autowired
     TestUtil testUtil;
+
     @Autowired
     PostRepository postRepository;
     @Autowired
@@ -48,7 +49,7 @@ class PostServiceTest {
     @Test
     void givenPostInfoAndUserInfo_whenAddingPost_thenReturnsSavedPostInfo() {
         // given
-        PostRequest postRequest = new PostRequest(TEST_TITLE, TEST_CONTENT);
+        PostRequest postRequest = new PostRequest(TEST_POST_TITLE, TEST_POST_CONTENT);
         UserAccountDTO userAccountDTO = testUtil.saveTestUser(TEST_USERNAME, TEST_PASSWORD);
         UserAccountPrincipal userAccountPrincipal = UserAccountPrincipal.from(userAccountDTO);
 
@@ -56,15 +57,15 @@ class PostServiceTest {
         PostDTO postDTO = postService.addPost(postRequest.toDTO(), userAccountPrincipal.toDTO());
 
         // then
-        assertThat(postDTO.title()).isEqualTo(TEST_TITLE);
-        assertThat(postDTO.content()).isEqualTo(TEST_CONTENT);
+        assertThat(postDTO.title()).isEqualTo(TEST_POST_TITLE);
+        assertThat(postDTO.content()).isEqualTo(TEST_POST_CONTENT);
     }
 
     @DisplayName("회원가입 되지 않은 회원정보로, 게시글 생성시, 예외를 던진다.")
     @Test
     void givenPostInfoWithUnRegisteredUserInfo_whenAddingPost_thenThrowsException() {
         // given
-        PostRequest postRequest = new PostRequest(TEST_TITLE, TEST_CONTENT);
+        PostRequest postRequest = new PostRequest(TEST_POST_TITLE, TEST_POST_CONTENT);
         long wrongUserId = 3L;
         UserAccountPrincipal userAccountPrincipal = new UserAccountPrincipal(wrongUserId,
             TEST_USERNAME, List.of("USER_ROLE"));

--- a/src/test/java/me/honki12345/hoonlog/service/PostServiceTest.java
+++ b/src/test/java/me/honki12345/hoonlog/service/PostServiceTest.java
@@ -53,7 +53,7 @@ class PostServiceTest {
         UserAccountPrincipal userAccountPrincipal = userAccountDTO.toPrincipal();
 
         // when
-        PostDTO postDTO = postService.addPost(postRequest, userAccountPrincipal);
+        PostDTO postDTO = postService.addPost(postRequest.toDTO(), UserAccountDTO.from(userAccountPrincipal));
 
         // then
         assertThat(postDTO.title()).isEqualTo(TEST_TITLE);
@@ -65,13 +65,13 @@ class PostServiceTest {
     void givenPostInfoWithUnRegisteredUserInfo_whenAddingPost_thenThrowsException() {
         // given
         PostRequest postRequest = new PostRequest(TEST_TITLE, TEST_CONTENT);
-        long wrongUserId = 1L;
+        long wrongUserId = 3L;
         UserAccountPrincipal userAccountPrincipal = new UserAccountPrincipal(wrongUserId,
             TEST_USERNAME, List.of("USER_ROLE"));
 
         // when // then
         assertThatThrownBy(() ->
-            postService.addPost(postRequest, userAccountPrincipal)).isInstanceOf(
+            postService.addPost(postRequest.toDTO(), UserAccountDTO.from(userAccountPrincipal))).isInstanceOf(
             UserAccountNotFoundException.class);
     }
 
@@ -88,8 +88,8 @@ class PostServiceTest {
 
         // when
         PostDTO updatedPostDTO = postService.updatePost(savedPost.getId(),
-            userAccountDTO.toPrincipal(),
-            updateRequest);
+            userAccountDTO,
+            updateRequest.toDTO());
 
         // then
         assertThat(updatedPostDTO.id()).isEqualTo(savedPost.getId());
@@ -107,7 +107,7 @@ class PostServiceTest {
 
         // when // then
         assertThatNoException().isThrownBy(
-            () -> postService.deletePost(savedPost.getId(), userAccountDTO.toPrincipal()));
+            () -> postService.deletePost(savedPost.getId(), userAccountDTO));
     }
 
 

--- a/src/test/java/me/honki12345/hoonlog/service/PostServiceTest.java
+++ b/src/test/java/me/honki12345/hoonlog/service/PostServiceTest.java
@@ -50,10 +50,10 @@ class PostServiceTest {
         // given
         PostRequest postRequest = new PostRequest(TEST_TITLE, TEST_CONTENT);
         UserAccountDTO userAccountDTO = testUtil.saveTestUser(TEST_USERNAME, TEST_PASSWORD);
-        UserAccountPrincipal userAccountPrincipal = userAccountDTO.toPrincipal();
+        UserAccountPrincipal userAccountPrincipal = UserAccountPrincipal.from(userAccountDTO);
 
         // when
-        PostDTO postDTO = postService.addPost(postRequest.toDTO(), UserAccountDTO.from(userAccountPrincipal));
+        PostDTO postDTO = postService.addPost(postRequest.toDTO(), userAccountPrincipal.toDTO());
 
         // then
         assertThat(postDTO.title()).isEqualTo(TEST_TITLE);
@@ -71,7 +71,7 @@ class PostServiceTest {
 
         // when // then
         assertThatThrownBy(() ->
-            postService.addPost(postRequest.toDTO(), UserAccountDTO.from(userAccountPrincipal))).isInstanceOf(
+            postService.addPost(postRequest.toDTO(), userAccountPrincipal.toDTO())).isInstanceOf(
             UserAccountNotFoundException.class);
     }
 

--- a/src/test/java/me/honki12345/hoonlog/service/UserAccountServiceTest.java
+++ b/src/test/java/me/honki12345/hoonlog/service/UserAccountServiceTest.java
@@ -8,7 +8,6 @@ import me.honki12345.hoonlog.dto.ProfileDTO;
 import me.honki12345.hoonlog.dto.UserAccountDTO;
 import me.honki12345.hoonlog.dto.request.UserAccountAddRequest;
 import me.honki12345.hoonlog.dto.request.UserAccountModifyRequest;
-import me.honki12345.hoonlog.repository.UserAccountRepository;
 import me.honki12345.hoonlog.util.TestUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,12 +34,10 @@ class UserAccountServiceTest {
 
     @Autowired
     private UserAccountService userAccountService;
-    @Autowired
-    private UserAccountRepository userAccountRepository;
 
     @AfterEach
     void tearDown() {
-        userAccountRepository.deleteAllInBatch();
+        testUtil.deleteAllInBatchInAllRepository();
     }
 
     @DisplayName("[가입/성공]유저 정보를 입력하면, 회원가입 시, id와 encoded 비밀번호와 가입일자 정보가 포함된 유저 객체를 생성한다.")

--- a/src/test/java/me/honki12345/hoonlog/service/UserAccountServiceTest.java
+++ b/src/test/java/me/honki12345/hoonlog/service/UserAccountServiceTest.java
@@ -9,27 +9,34 @@ import me.honki12345.hoonlog.dto.UserAccountDTO;
 import me.honki12345.hoonlog.dto.request.UserAccountAddRequest;
 import me.honki12345.hoonlog.dto.request.UserAccountModifyRequest;
 import me.honki12345.hoonlog.repository.UserAccountRepository;
+import me.honki12345.hoonlog.util.TestUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
+import static me.honki12345.hoonlog.util.TestUtil.*;
 import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("UserAccountService 애플리케이션 통합테스트")
 @ActiveProfiles("test")
+@Import({TestUtil.class})
 @SpringBootTest
 class UserAccountServiceTest {
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private TestUtil testUtil;
 
     @Autowired
     private UserAccountService userAccountService;
     @Autowired
     private UserAccountRepository userAccountRepository;
-    @Autowired
-    private PasswordEncoder passwordEncoder;
 
     @AfterEach
     void tearDown() {
@@ -46,7 +53,7 @@ class UserAccountServiceTest {
             "fpg123", userPassword, "fpg123@mail.com", profileDTO);
 
         // when
-        UserAccountDTO actual = userAccountService.saveUserAccount(request);
+        UserAccountDTO actual = userAccountService.saveUserAccount(request.toDTO());
 
         // then
         assertThat(actual)
@@ -62,10 +69,10 @@ class UserAccountServiceTest {
         ProfileDTO profileDTO = new ProfileDTO("blogName", null);
         UserAccountAddRequest request = new UserAccountAddRequest(
             "fpg123", "12345678", "fpg123@mail.com", profileDTO);
-        userAccountService.saveUserAccount(request);
+        userAccountService.saveUserAccount(request.toDTO());
 
         // when // then
-        assertThatThrownBy(() -> userAccountService.saveUserAccount(request)).isInstanceOf(
+        assertThatThrownBy(() -> userAccountService.saveUserAccount(request.toDTO())).isInstanceOf(
             DuplicateUserAccountException.class);
     }
 
@@ -82,13 +89,12 @@ class UserAccountServiceTest {
     @Test
     void givenLoginInfo_whenFindEntityCheckingPassword_thenReturnsEntity() {
         // given
-        String password = "12345678";
-        UserAccountDTO userAccountDTO = saveOneUserAccount("fpg123", password);
-        LoginRequest loginRequest = new LoginRequest(userAccountDTO.username(), password);
+        UserAccountDTO userAccountDTO = testUtil.saveTestUser();
+        LoginRequest loginRequest = new LoginRequest(userAccountDTO.username(), TEST_PASSWORD);
 
         // when
         UserAccountDTO findUserAccountDTO = userAccountService.findUserAccountAfterCheckingPassword(
-            loginRequest);
+            loginRequest.toDTO());
 
         // then
         assertThat(findUserAccountDTO).hasFieldOrPropertyWithValue("id", userAccountDTO.id())
@@ -100,13 +106,12 @@ class UserAccountServiceTest {
     @Test
     void givenWrongUsername_whenFindEntityCheckingPassword_thenReturnsEntity() {
         // given
-        String password = "12345678";
-        saveOneUserAccount("fpg123", password);
-        LoginRequest loginRequest = new LoginRequest("wrongUserId", password);
+        testUtil.saveTestUser();
+        LoginRequest loginRequest = new LoginRequest("wrongUserId", TEST_PASSWORD);
 
         // when
         assertThatThrownBy(
-            () -> userAccountService.findUserAccountAfterCheckingPassword(loginRequest))
+            () -> userAccountService.findUserAccountAfterCheckingPassword(loginRequest.toDTO()))
             .isInstanceOf(LoginErrorException.class);
     }
 
@@ -114,13 +119,12 @@ class UserAccountServiceTest {
     @Test
     void givenWrongPassword_whenFindEntityCheckingPassword_thenReturnsEntity() {
         // given
-        String username = "fpg123";
-        saveOneUserAccount(username, "12345678");
-        LoginRequest loginRequest = new LoginRequest(username, "wrongPassword");
+        testUtil.saveTestUser();
+        LoginRequest loginRequest = new LoginRequest(TEST_USERNAME, "wrongPassword");
 
         // when
         assertThatThrownBy(
-            () -> userAccountService.findUserAccountAfterCheckingPassword(loginRequest))
+            () -> userAccountService.findUserAccountAfterCheckingPassword(loginRequest.toDTO()))
             .isInstanceOf(LoginErrorException.class);
     }
 
@@ -131,7 +135,7 @@ class UserAccountServiceTest {
         ProfileDTO profileDTO = new ProfileDTO("blogName", null);
         UserAccountAddRequest request = new UserAccountAddRequest(
             "fpg123", "12345678", "fpg123@mail.com", profileDTO);
-        userAccountService.saveUserAccount(request);
+        userAccountService.saveUserAccount(request.toDTO());
 
         String changedBlogName = "changedBlogName";
         String changedBlogBio = "changedBlogBio";
@@ -141,7 +145,7 @@ class UserAccountServiceTest {
 
         // when
         UserAccountDTO userAccountDTO = userAccountService.modifyUserAccount("fpg123",
-            modifyRequest);
+            modifyRequest.toDTO());
         ProfileDTO changedProfileDTO = userAccountDTO.profileDTO();
 
         // then
@@ -159,27 +163,8 @@ class UserAccountServiceTest {
         );
 
         // when // then
-        assertThatThrownBy(() -> userAccountService.modifyUserAccount("wrongUserId", modifyRequest))
+        assertThatThrownBy(
+            () -> userAccountService.modifyUserAccount("wrongUserId", modifyRequest.toDTO()))
             .isInstanceOf(UserAccountNotFoundException.class);
     }
-
-    private UserAccountDTO saveOneUserAccount(String username, String password) {
-        ProfileDTO profileDTO = new ProfileDTO("blogName", null);
-        return saveOneUserAccount(username, password, "fpg123@mail.com", profileDTO);
-    }
-
-
-    private UserAccountDTO saveOneUserAccount(String username, String password, String email) {
-        ProfileDTO profileDTO = new ProfileDTO("blogName", null);
-        return saveOneUserAccount(username, password, email, profileDTO);
-    }
-
-
-    private UserAccountDTO saveOneUserAccount(String username, String password, String email,
-        ProfileDTO profileDTO) {
-        UserAccountAddRequest request = new UserAccountAddRequest(username, password, email,
-            profileDTO);
-        return userAccountService.saveUserAccount(request);
-    }
-
 }

--- a/src/test/java/me/honki12345/hoonlog/util/TestUtil.java
+++ b/src/test/java/me/honki12345/hoonlog/util/TestUtil.java
@@ -9,6 +9,7 @@ import me.honki12345.hoonlog.dto.TokenDTO;
 import me.honki12345.hoonlog.dto.UserAccountDTO;
 import me.honki12345.hoonlog.dto.request.PostRequest;
 import me.honki12345.hoonlog.dto.request.UserAccountAddRequest;
+import me.honki12345.hoonlog.repository.PostCommentRepository;
 import me.honki12345.hoonlog.repository.PostRepository;
 import me.honki12345.hoonlog.repository.RefreshTokenRepository;
 import me.honki12345.hoonlog.repository.UserAccountRepository;
@@ -22,8 +23,9 @@ public class TestUtil {
 
     public static final String TEST_USERNAME = "fpg123";
     public static final String TEST_PASSWORD = "12345678";
-    public static final String TEST_TITLE= "title";
-    public static final String TEST_CONTENT= "content";
+    public static final String TEST_POST_TITLE = "title";
+    public static final String TEST_POST_CONTENT = "content";
+    public static final String TEST_COMMENT_CONTENT = "commentContent";
 
     private final AuthService authService;
     private final UserAccountService userAccountService;
@@ -31,20 +33,22 @@ public class TestUtil {
     private final PostRepository postRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserAccountRepository userAccountRepository;
+    private final PostCommentRepository postCommentRepository;
 
 
     public void deleteAllInBatchInAllRepository() {
+        this.postCommentRepository.deleteAllInBatch();
         this.postRepository.deleteAllInBatch();
         this.refreshTokenRepository.deleteAllInBatch();
         this.userAccountRepository.deleteAllInBatch();
     }
 
-    public TokenDTO createTokensAfterSaving() {
+    public TokenDTO createTokensAfterSavingTestUser() {
         UserAccountDTO userAccountDTO = saveTestUser();
         return authService.createTokens(userAccountDTO);
     }
 
-    public TokenDTO createTokensAfterSaving(String username, String password) {
+    public TokenDTO createTokensAfterSavingTestUser(String username, String password) {
         UserAccountDTO userAccountDTO = saveTestUser(username, password);
         return authService.createTokens(userAccountDTO);
     }
@@ -71,6 +75,13 @@ public class TestUtil {
         UserAccountAddRequest request = new UserAccountAddRequest(username, password, email,
             profileDTO);
         return userAccountService.saveUserAccount(request.toDTO());
+    }
+
+    public Post createPostWithTestUser() {
+        PostRequest postRequest = new PostRequest(TEST_POST_TITLE, TEST_POST_CONTENT);
+        Optional<UserAccount> optionalUserAccount = userAccountRepository.findByUsername(TEST_USERNAME);
+        return optionalUserAccount.map(userAccount -> postRepository.saveAndFlush(
+            postRequest.toDTO().toEntity().addUserAccount(userAccount))).orElse(null);
     }
 
     public Post createPostWithTestUser(String title, String content) {

--- a/src/test/java/me/honki12345/hoonlog/util/TestUtil.java
+++ b/src/test/java/me/honki12345/hoonlog/util/TestUtil.java
@@ -13,7 +13,6 @@ import me.honki12345.hoonlog.repository.PostRepository;
 import me.honki12345.hoonlog.repository.RefreshTokenRepository;
 import me.honki12345.hoonlog.repository.UserAccountRepository;
 import me.honki12345.hoonlog.service.AuthService;
-import me.honki12345.hoonlog.service.PostService;
 import me.honki12345.hoonlog.service.UserAccountService;
 import org.springframework.boot.test.context.TestComponent;
 
@@ -22,14 +21,12 @@ import org.springframework.boot.test.context.TestComponent;
 public class TestUtil {
 
     public static final String TEST_USERNAME = "fpg123";
-    public static final String TEST_WRONG_USERNAME = "wrongFpg123";
     public static final String TEST_PASSWORD = "12345678";
     public static final String TEST_TITLE= "title";
     public static final String TEST_CONTENT= "content";
 
     private final AuthService authService;
     private final UserAccountService userAccountService;
-    private final PostService postService;
 
     private final PostRepository postRepository;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -73,13 +70,13 @@ public class TestUtil {
         ProfileDTO profileDTO) {
         UserAccountAddRequest request = new UserAccountAddRequest(username, password, email,
             profileDTO);
-        return userAccountService.saveUserAccount(request);
+        return userAccountService.saveUserAccount(request.toDTO());
     }
 
     public Post createPostWithTestUser(String title, String content) {
         PostRequest postRequest = new PostRequest(title, content);
         Optional<UserAccount> optionalUserAccount = userAccountRepository.findByUsername(TEST_USERNAME);
         return optionalUserAccount.map(userAccount -> postRepository.save(
-            postRequest.toEntityWithUserAccount(userAccount))).orElse(null);
+            postRequest.toDTO().toEntity().addUserAccount(userAccount))).orElse(null);
     }
 }


### PR DESCRIPTION
댓글(PostComment) 엔티티를 설계하고
생성, 조회, 수정, 삭제 기능 구현을 하여 API, 서비스로직, 테스트를 마쳤다.

---

1. 게시글(Post)와 댓글(PostComment)는 일대다 관계인데
영속성 관리와 삭제의 편리성을 위해  `CascadeType.ALL` 설정을 하였다.

2. 일정을 맞추기 위하여 성공 케이스만 테스트 작성하였고 추후에 실패 케이스 추가할 예정이다.