### PR TITLE
태그생성과 태그에 따른 게시물 조회 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/gradle,java,windows
+
+# Q클래스
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.4'
@@ -24,6 +30,13 @@ repositories {
 dependencies {
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // queryDSL 설정
+    // querydsl
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    //java.lang.NoClassDefFoundError 대응
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
@@ -53,4 +66,22 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// Querydsl Q Class 생성 위치
+def querydslDir = '/src/main/generated/'
+
+// Querydsl Q Class 생성 위치 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+// java source set 에 Querydsl Q Class 위치 추가
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+// gradle clean 시, Q Class 디렉토리까지 삭제하도록 설정
+clean {
+    delete file(querydslDir)
 }

--- a/src/main/java/me/honki12345/hoonlog/controller/PostController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostController.java
@@ -4,11 +4,13 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import me.honki12345.hoonlog.dto.PostDTO;
+import me.honki12345.hoonlog.dto.TagDTO;
 import me.honki12345.hoonlog.dto.request.PostRequest;
 import me.honki12345.hoonlog.dto.response.PostResponse;
 import me.honki12345.hoonlog.dto.security.UserAccountPrincipal;
 import me.honki12345.hoonlog.security.jwt.util.IfLogin;
 import me.honki12345.hoonlog.service.PostService;
+import me.honki12345.hoonlog.service.TagService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
@@ -31,6 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class PostController {
 
     private final PostService postService;
+    private final TagService tagService;
 
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponse> searchPost(@PathVariable Long postId) {
@@ -41,10 +44,21 @@ public class PostController {
     @GetMapping
     public ResponseEntity<Page<PostResponse>> searchPosts(
         @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
-        Page<PostResponse> responses = postService.searchPosts(pageable)
+        Page<PostResponse> responses = postService.searchPostsByTagName(pageable)
             .map(PostResponse::from);
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }
+
+    @GetMapping("/tag/{tagName}")
+    public ResponseEntity<Page<PostResponse>> searchPostsByTag(
+        @PathVariable String tagName,
+        @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+        TagDTO tagDTO = TagDTO.fromWithoutPostIds(tagService.searchTag(tagName));
+        Page<PostResponse> responses = postService.searchPostsByTagName(pageable, tagDTO)
+            .map(PostResponse::from);
+        return new ResponseEntity<>(responses, HttpStatus.OK);
+    }
+
 
     @PostMapping
     public ResponseEntity<PostResponse> addPost(

--- a/src/main/java/me/honki12345/hoonlog/domain/Post.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/Post.java
@@ -141,4 +141,12 @@ public class Post extends AuditingFields {
         tags.forEach(tag -> tag.addPost(this));
         return this;
     }
+
+    public Post updateTags(Set<Tag> newTags) {
+        this.tags.forEach(tag -> tag.deletePost(this));
+        this.tags = newTags;
+        newTags.forEach(tag -> tag.addPost(this));
+        return this;
+    }
+
 }

--- a/src/main/java/me/honki12345/hoonlog/domain/PostComment.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/PostComment.java
@@ -39,6 +39,10 @@ public class PostComment extends AuditingFields {
         this.content = content;
     }
 
+    public static PostComment of(Long id, String content) {
+        return PostComment.of(id, null, null, content);
+    }
+
     public static PostComment of(Long id, Post post, UserAccount userAccount, String content) {
         return new PostComment(id, post, userAccount, content);
     }

--- a/src/main/java/me/honki12345/hoonlog/domain/PostImage.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/PostImage.java
@@ -11,6 +11,7 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import me.honki12345.hoonlog.domain.vo.AuditingFields;
 
 @Getter
@@ -33,13 +34,35 @@ public class PostImage extends AuditingFields {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    public void addPost(Post post) {
+    private PostImage(Long id, String imgName, String originalImgName, String imgUrl, Post post) {
+        this.id = id;
+        this.imgName = imgName;
+        this.originalImgName = originalImgName;
+        this.imgUrl = imgUrl;
         this.post = post;
-        post.getPostImages().add(this);
     }
 
-    public void updatePostImage(String originalImgName, String imgName, String imgUrl) {
-        this.originalImgName = originalImgName;
+    public static PostImage of(Post post) {
+        PostImage postImage = new PostImage();
+        postImage.addPost(post);
+        return postImage;
+    }
+
+    public static PostImage of(String originalImgName, String imgName, String imgUrl) {
+        return new PostImage(null, imgName, originalImgName, imgUrl, null);
+    }
+
+    public static PostImage of(Long id, String imgName, String originalImgName, String imgUrl,
+        Post post) {
+        return new PostImage(id, imgName, originalImgName, imgUrl, post);
+    }
+
+    public void addPost(Post post) {
+        this.post = post;
+    }
+
+    public void updatePostImage(String originalFilename, String imgName, String imgUrl) {
+        this.originalImgName = originalFilename;
         this.imgName = imgName;
         this.imgUrl = imgUrl;
     }

--- a/src/main/java/me/honki12345/hoonlog/domain/Tag.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/Tag.java
@@ -1,0 +1,72 @@
+package me.honki12345.hoonlog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.honki12345.hoonlog.domain.vo.AuditingFields;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Tag extends AuditingFields {
+
+    @Id
+    @Column(name = "tag_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToMany(mappedBy = "tags")
+    private Set<Post> posts = new LinkedHashSet<>();
+
+    public Tag(Long id, String name, Set<Post> posts) {
+        this.id = id;
+        this.name = name;
+        this.posts = posts;
+    }
+
+    private Tag(String name) {
+        this.name = name;
+    }
+
+    public static Tag of(String tagName) {
+        return new Tag(tagName);
+    }
+
+    public static Tag of(Long id, String name, Set<Post> posts) {
+        return new Tag(id, name, posts);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Tag tag)) {
+            return false;
+        }
+        return Objects.equals(name, tag.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    public Tag addPost(Post post) {
+        this.posts.add(post);
+        return this;
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/domain/Tag.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/Tag.java
@@ -69,4 +69,8 @@ public class Tag extends AuditingFields {
         this.posts.add(post);
         return this;
     }
+
+    public void deletePost(Post post) {
+        this.posts.remove(post);
+    }
 }

--- a/src/main/java/me/honki12345/hoonlog/domain/util/FileUtil.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/util/FileUtil.java
@@ -5,7 +5,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import me.honki12345.hoonlog.domain.PostImage;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Component
@@ -40,4 +43,18 @@ public class FileUtil {
             log.info("파일이 존재하지 않습니다: {}", filePath);
         }
     }
+
+    public PostImage fromMultipartFileToPostImage(MultipartFile postImageFile) throws IOException {
+        String originalFilename = postImageFile.getOriginalFilename();
+        if (!StringUtils.hasText(originalFilename)) {
+            throw new IOException();
+        }
+        String imageName = uploadFile(FileUtil.IMAGE_LOCATION,
+            originalFilename,
+            postImageFile.getBytes());
+        String imageUrl = FileUtil.UPLOAD_URL + imageName;
+
+        return PostImage.of(originalFilename, imageName, imageUrl);
+    }
+
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/PostCommentDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/PostCommentDTO.java
@@ -1,15 +1,14 @@
 package me.honki12345.hoonlog.dto;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
-import me.honki12345.hoonlog.domain.Post;
+import java.util.Set;
+import java.util.stream.Collectors;
 import me.honki12345.hoonlog.domain.PostComment;
-import me.honki12345.hoonlog.domain.UserAccount;
 
 public record PostCommentDTO(
     Long id,
-    PostDTO postDTO,
-    UserAccountDTO userAccountDTO,
+    Long postId,
+    Long userId,
     String content,
     LocalDateTime createdAt,
     String createdBy,
@@ -21,16 +20,18 @@ public record PostCommentDTO(
     }
 
     public static PostCommentDTO from(PostComment entity) {
-        return new PostCommentDTO(entity.getId(), PostDTO.from(entity.getPost()),
-            UserAccountDTO.from(entity.getUserAccount()),
+        return new PostCommentDTO(entity.getId(), entity.getPost().getId(),
+            entity.getUserAccount().getId(),
             entity.getContent(), entity.getCreatedAt(), entity.getCreatedBy(),
             entity.getModifiedAt());
     }
 
+    public static Set<PostCommentDTO> from(Set<PostComment> postComments) {
+        return postComments.stream().map(PostCommentDTO::from)
+            .collect(Collectors.toUnmodifiableSet());
+    }
+
     public PostComment toEntity() {
-        Post post = Optional.ofNullable(postDTO).map(PostDTO::toEntity).orElse(null);
-        UserAccount userAccount = Optional.ofNullable(userAccountDTO).map(UserAccountDTO::toEntity)
-            .orElse(null);
-        return PostComment.of(id, post, userAccount, content);
+        return PostComment.of(id, content);
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/PostDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/PostDTO.java
@@ -2,51 +2,58 @@ package me.honki12345.hoonlog.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import me.honki12345.hoonlog.domain.Post;
-import me.honki12345.hoonlog.domain.UserAccount;
+import me.honki12345.hoonlog.domain.PostImage;
+import me.honki12345.hoonlog.domain.Tag;
 
 public record PostDTO(
     Long id,
-    UserAccountDTO userAccountDTO,
+    Long userId,
     String title,
     String content,
     LocalDateTime createdAt,
     String createdBy,
     LocalDateTime modifiedAt,
     String modifiedBy,
-    List<PostImageDTO> postImageDTOs,
-    List<Long> postImageIds
+    List<Long> postImageIds,
+    Set<Long> tagIds
 
 ) {
 
     public static PostDTO from(Post entity) {
         return new PostDTO(
             entity.getId(),
-            UserAccountDTO.from(entity.getUserAccount()),
+            entity.getUserAccount().getId(),
             entity.getTitle(),
             entity.getContent(),
             entity.getCreatedAt(),
             entity.getCreatedBy(),
             entity.getModifiedAt(),
             entity.getModifiedBy(),
-            PostImageDTO.from(entity.getPostImages()),
-            null
+            entity.getPostImages().stream().map(PostImage::getId).collect(Collectors.toList()),
+            entity.getTags().stream().map(Tag::getId).collect(Collectors.toUnmodifiableSet())
         );
     }
 
     public static PostDTO of(String title, String content, List<Long> postImageIds) {
-        return new PostDTO(null, null, title, content, null, null, null, null, null, postImageIds);
+        return PostDTO.of(title, content, postImageIds, null);
+    }
+
+    public static PostDTO of(String title, String content, List<Long> postImageIds,
+        Set<Long> tagIds) {
+        return new PostDTO(null, null, title, content, null, null, null, null,  postImageIds,
+            tagIds);
     }
 
     public Post toEntity() {
-        UserAccount userAccount = Optional.ofNullable(userAccountDTO).map(UserAccountDTO::toEntity)
-            .orElse(null);
-        return Post.of(id, userAccount, title, content);
+        return Post.of(id, title, content);
     }
 
     public PostDTO addPostImageDTOs(List<PostImageDTO> dtos) {
-        return new PostDTO(this.id, this.userAccountDTO, this.title, this.content, this.createdAt,
-            this.createdBy, this.modifiedAt, this.modifiedBy, dtos, this.postImageIds);
+        return new PostDTO(this.id, this.userId, this.title, this.content, this.createdAt,
+            this.createdBy, this.modifiedAt, this.modifiedBy, this.postImageIds,
+            this.tagIds);
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/PostImageDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/PostImageDTO.java
@@ -2,21 +2,29 @@ package me.honki12345.hoonlog.dto;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import me.honki12345.hoonlog.domain.Post;
 import me.honki12345.hoonlog.domain.PostImage;
 
 public record PostImageDTO(
     Long id,
     String imgName,
     String originalImgName,
-    String imgUrl
+    String imgUrl,
+    Long postId
 ) {
 
     public static PostImageDTO from(PostImage postImage) {
         return new PostImageDTO(postImage.getId(), postImage.getImgName(),
-            postImage.getOriginalImgName(), postImage.getImgUrl());
+            postImage.getOriginalImgName(), postImage.getImgUrl(), postImage.getPost().getId());
     }
+
 
     public static List<PostImageDTO> from(List<PostImage> postImages) {
         return postImages.stream().map(PostImageDTO::from).collect(Collectors.toList());
+    }
+
+    public PostImage toEntity() {
+        return PostImage.of(this.id, this.imgName, this.originalImgName, this.imgUrl,
+            Post.of(this.postId));
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/TagDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/TagDTO.java
@@ -1,0 +1,29 @@
+package me.honki12345.hoonlog.dto;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import me.honki12345.hoonlog.domain.Post;
+import me.honki12345.hoonlog.domain.Tag;
+
+public record TagDTO(
+    Long id,
+    String tagName,
+    Set<Long> postIds
+) {
+
+    public static TagDTO of(String tagName) {
+        return new TagDTO(null, tagName, null);
+    }
+
+    public static TagDTO fromWithoutPostIds(Tag tag) {
+        return new TagDTO(tag.getId(), tag.getName(), null);
+    }
+
+    public static Set<TagDTO> fromWithoutPostIds(Set<Tag> tags) {
+        return tags.stream().map(TagDTO::fromWithoutPostIds).collect(Collectors.toUnmodifiableSet());
+    }
+
+    public Tag toEntity() {
+        return Tag.of(this.id, this.tagName, null);
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/dto/request/PostRequest.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/request/PostRequest.java
@@ -2,24 +2,40 @@ package me.honki12345.hoonlog.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import me.honki12345.hoonlog.dto.PostDTO;
 
 public record PostRequest(
     @NotNull(message = "제목을 입력해주세요")
     String title,
     String content,
-    List<Long> postImageIds
+    List<Long> postImageIds,
+    Set<String> tagNames
 ) {
 
     public PostRequest {
         if (Objects.isNull(postImageIds)) {
             postImageIds = new ArrayList<>();
         }
+
+        if (Objects.isNull(tagNames)) {
+            tagNames = new LinkedHashSet<>();
+        }
+    }
+
+    public static PostRequest of(String title, String content) {
+        return new PostRequest(title, content, null, null);
+    }
+
+    public static PostRequest of(String title, String content, Set<String> tagNames) {
+        return new PostRequest(title, content, null, tagNames);
     }
 
     public PostDTO toDTO() {
         return PostDTO.of(title, content, postImageIds);
     }
+
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/response/PostResponse.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/response/PostResponse.java
@@ -2,8 +2,12 @@ package me.honki12345.hoonlog.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import me.honki12345.hoonlog.domain.Post;
+import me.honki12345.hoonlog.dto.PostCommentDTO;
 import me.honki12345.hoonlog.dto.PostDTO;
 import me.honki12345.hoonlog.dto.PostImageDTO;
+import me.honki12345.hoonlog.dto.TagDTO;
 
 public record PostResponse(
     Long id,
@@ -11,18 +15,35 @@ public record PostResponse(
     String content,
     String createdBy,
     LocalDateTime createdAt,
-    List<PostImageDTO> postImageDTOs
+    List<PostImageDTO> postImageDTOs,
+    Set<PostCommentDTO> postCommentDTOs,
+    Set<TagDTO> tagDTOs
 ) {
 
-    public static PostResponse from(PostDTO dto) {
+    public static PostResponse from(PostDTO postDTO, List<PostImageDTO> postImageDTOs,
+        Set<PostCommentDTO> postCommentDTOs, Set<TagDTO> tagDTOs) {
+
         return new PostResponse(
-            dto.id(),
-            dto.title(),
-            dto.content(),
-            dto.createdBy(),
-            dto.createdAt(),
-            dto.postImageDTOs()
+            postDTO.id(),
+            postDTO.title(),
+            postDTO.content(),
+            postDTO.createdBy(),
+            postDTO.createdAt(),
+            postImageDTOs,
+            postCommentDTOs,
+            tagDTOs
         );
+    }
+
+    public static PostResponse from(PostDTO post) {
+        return new PostResponse(post.id(), post.title(), post.content(), post.createdBy(),
+            post.createdAt(), null, null, null);
+    }
+
+
+    public static PostResponse from(Post post) {
+        return from(PostDTO.from(post), PostImageDTO.from(post.getPostImages()),
+            PostCommentDTO.from(post.getPostComments()), TagDTO.fromWithoutPostIds(post.getTags()));
     }
 
 }

--- a/src/main/java/me/honki12345/hoonlog/error/ErrorCode.java
+++ b/src/main/java/me/honki12345/hoonlog/error/ErrorCode.java
@@ -29,7 +29,9 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT1", "댓글을 찾을 수 없습니다"),
 
     IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "IMAGE1", "파일 업로드에 실패하였습니다"),
-    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE2", "파일을 찾을 수 없습니다");
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE2", "파일을 찾을 수 없습니다"),
+
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "TAG1", "태그를 찾을 수 없습니다");
 
     private final String message;
     private final String code;

--- a/src/main/java/me/honki12345/hoonlog/error/exception/domain/TagNotFoundException.java
+++ b/src/main/java/me/honki12345/hoonlog/error/exception/domain/TagNotFoundException.java
@@ -1,0 +1,11 @@
+package me.honki12345.hoonlog.error.exception.domain;
+
+import me.honki12345.hoonlog.error.ErrorCode;
+import me.honki12345.hoonlog.error.exception.NotFoundException;
+
+public class TagNotFoundException extends NotFoundException {
+
+    public TagNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/repository/PostCommentRepository.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/PostCommentRepository.java
@@ -1,8 +1,10 @@
 package me.honki12345.hoonlog.repository;
 
+import java.util.List;
 import me.honki12345.hoonlog.domain.PostComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
 
+    List<PostComment> findAllByPost_id(Long postId);
 }

--- a/src/main/java/me/honki12345/hoonlog/repository/PostImageRepository.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/PostImageRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
-    List<PostImage> findAllByPostId(Long postId);
+    List<PostImage> findByPost_Id(Long postId);
 }

--- a/src/main/java/me/honki12345/hoonlog/repository/PostRepository.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/PostRepository.java
@@ -2,13 +2,15 @@ package me.honki12345.hoonlog.repository;
 
 import java.util.Optional;
 import me.honki12345.hoonlog.domain.Post;
+import me.honki12345.hoonlog.domain.Tag;
+import me.honki12345.hoonlog.repository.querydsl.PostRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
     @Query("SELECT p FROM Post p "
         + "LEFT JOIN FETCH p.postImages LEFT JOIN FETCH p.postComments LEFT JOIN FETCH p.tags "

--- a/src/main/java/me/honki12345/hoonlog/repository/PostRepository.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/PostRepository.java
@@ -1,8 +1,21 @@
 package me.honki12345.hoonlog.repository;
 
+import java.util.Optional;
 import me.honki12345.hoonlog.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
+    @Query("SELECT p FROM Post p "
+        + "LEFT JOIN FETCH p.postImages LEFT JOIN FETCH p.postComments LEFT JOIN FETCH p.tags "
+        + "WHERE p.id = :postId")
+    Optional<Post> findByPostIdWithAll(@Param("postId") Long postId);
+
+    @Query("SELECT p FROM Post p "
+        + "LEFT JOIN FETCH p.postImages LEFT JOIN FETCH p.postComments LEFT JOIN FETCH p.tags")
+    Page<Post> findAllWithAll(Pageable pageable);
 }

--- a/src/main/java/me/honki12345/hoonlog/repository/TagRepository.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/TagRepository.java
@@ -1,0 +1,10 @@
+package me.honki12345.hoonlog.repository;
+
+import java.util.Optional;
+import me.honki12345.hoonlog.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Optional<Tag> findByName(String name);
+}

--- a/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustom.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustom.java
@@ -1,0 +1,11 @@
+package me.honki12345.hoonlog.repository.querydsl;
+
+import me.honki12345.hoonlog.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepositoryCustom {
+
+    Page<Post> findByTagName(String tagName, Pageable pageable);
+
+}

--- a/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustomImpl.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustomImpl.java
@@ -1,0 +1,39 @@
+package me.honki12345.hoonlog.repository.querydsl;
+
+import com.querydsl.jpa.JPQLQuery;
+import java.util.List;
+import me.honki12345.hoonlog.domain.Post;
+import me.honki12345.hoonlog.domain.QPost;
+import me.honki12345.hoonlog.domain.QPostComment;
+import me.honki12345.hoonlog.domain.QPostImage;
+import me.honki12345.hoonlog.domain.QTag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+public class PostRepositoryCustomImpl extends QuerydslRepositorySupport implements PostRepositoryCustom {
+
+    public PostRepositoryCustomImpl() {
+        super(Post.class);
+    }
+
+    @Override
+    public Page<Post> findByTagName(String tagName, Pageable pageable) {
+        QPost post = QPost.post;
+        QTag tag = QTag.tag;
+        QPostComment postComment = QPostComment.postComment;
+        QPostImage postImage = QPostImage.postImage;
+
+        JPQLQuery<Post> query = from(post)
+            .innerJoin(post.tags, tag).fetchJoin()
+            .leftJoin(post.postComments, postComment).fetchJoin()
+            .leftJoin(post.postImages, postImage).fetchJoin()
+            .where(tag.name.in(tagName));
+
+        List<Post> posts = getQuerydsl().applyPagination(pageable, query).fetch();
+        return new PageImpl<>(posts, pageable, query.fetchCount());
+
+
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/service/PostCommentService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/PostCommentService.java
@@ -1,5 +1,7 @@
 package me.honki12345.hoonlog.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import me.honki12345.hoonlog.domain.Post;
 import me.honki12345.hoonlog.domain.PostComment;
@@ -25,6 +27,11 @@ public class PostCommentService {
     private final PostCommentRepository postCommentRepository;
     private final UserAccountRepository userAccountRepository;
     private final PostRepository postRepository;
+
+    public List<PostCommentDTO> searchPostCommentsByPostId(Long postId) {
+        return postCommentRepository.findAllByPost_id(postId).stream().map(PostCommentDTO::from)
+            .collect(Collectors.toList());
+    }
 
     public PostCommentDTO addPostComment(PostCommentDTO postCommentDTO,
         Long postId, UserAccountDTO userAccountDTO) {

--- a/src/main/java/me/honki12345/hoonlog/service/PostService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/PostService.java
@@ -75,7 +75,7 @@ public class PostService {
         Set<Tag> tags =
             tagNames.isEmpty() ? Collections.emptySet() : tagNames.stream().map(Tag::of).collect(
                 Collectors.toUnmodifiableSet());
-        post.addTags(tags);
+        post.updateTags(tags);
 
         List<Long> postImageIds = postDTO.postImageIds();
         if (postImageFiles != null) {

--- a/src/main/java/me/honki12345/hoonlog/service/PostService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/PostService.java
@@ -1,18 +1,20 @@
 package me.honki12345.hoonlog.service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import me.honki12345.hoonlog.domain.Post;
-import me.honki12345.hoonlog.domain.PostImage;
+import me.honki12345.hoonlog.domain.Tag;
 import me.honki12345.hoonlog.domain.UserAccount;
 import me.honki12345.hoonlog.dto.PostDTO;
-import me.honki12345.hoonlog.dto.PostImageDTO;
 import me.honki12345.hoonlog.dto.UserAccountDTO;
 import me.honki12345.hoonlog.error.ErrorCode;
 import me.honki12345.hoonlog.error.exception.ForbiddenException;
 import me.honki12345.hoonlog.error.exception.domain.PostNotFoundException;
 import me.honki12345.hoonlog.error.exception.domain.UserAccountNotFoundException;
-import me.honki12345.hoonlog.repository.PostImageRepository;
 import me.honki12345.hoonlog.repository.PostRepository;
 import me.honki12345.hoonlog.repository.UserAccountRepository;
 import org.springframework.data.domain.Page;
@@ -29,59 +31,51 @@ public class PostService {
     private final PostImageService postImageService;
     private final PostRepository postRepository;
     private final UserAccountRepository userAccountRepository;
-    private final PostImageRepository postImageRepository;
 
     @Transactional(readOnly = true)
-    public Page<PostDTO> searchPosts(Pageable pageable) {
-        return postRepository.findAll(pageable).map(PostDTO::from)
-            .map(postDTO -> postDTO.addPostImageDTOs(
-                PostImageDTO.from(postImageRepository.findAllByPostId(
-                    postDTO.id()))));
-
+    public Post searchPost(Long postId) {
+        return postRepository.findByPostIdWithAll(postId)
+            .orElseThrow(() -> new PostNotFoundException(
+                ErrorCode.POST_NOT_FOUND));
     }
 
-    public PostDTO addPost(PostDTO postDTO,
+    @Transactional(readOnly = true)
+    public Page<Post> searchPosts(Pageable pageable) {
+        return postRepository.findAllWithAll(pageable);
+    }
+
+    public Post addPost(PostDTO postDTO,
         List<MultipartFile> postImageFiles,
-        UserAccountDTO userAccountDTO) {
+        Set<String> tagNames, UserAccountDTO userAccountDTO) {
         UserAccount userAccount = userAccountRepository.findById(userAccountDTO.id())
             .orElseThrow(() -> new UserAccountNotFoundException(
                 ErrorCode.USER_ACCOUNT_NOT_FOUND));
+
         Post post = postDTO.toEntity();
         post.addUserAccount(userAccount);
+        Optional.ofNullable(postImageFiles).ifPresent(
+            multipartFiles -> postImageService.savePostImagesWithPost(postImageFiles, post));
+        post.addTags(tagNames.isEmpty() ?
+            Collections.emptySet() : tagNames.stream().map(Tag::of).collect(
+            Collectors.toUnmodifiableSet()));
 
-        if (postImageFiles != null) {
-            for (MultipartFile multipartFile : postImageFiles) {
-                PostImage postImage = new PostImage();
-                postImage.addPost(post);
-                postImageService.savePostImage(postImage, multipartFile);
-            }
-        }
-
-        return PostDTO.from(postRepository.save(post));
+        return postRepository.save(post);
     }
 
-    @Transactional(readOnly = true)
-    public PostDTO searchPost(Long postId) {
-        PostDTO postDTO = PostDTO.from(postRepository.findById(postId)
-            .orElseThrow(() -> new PostNotFoundException(ErrorCode.POST_NOT_FOUND)));
-
-        List<PostImage> postImages = postImageRepository.findAllByPostId(postId);
-
-        if (!postImages.isEmpty()) {
-            postDTO.addPostImageDTOs(PostImageDTO.from(postImages));
-        }
-
-        return postDTO;
-    }
-
-    public PostDTO updatePost(Long postId, UserAccountDTO userAccountDTO,
-        PostDTO postDTO, List<MultipartFile> postImageFiles) {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new PostNotFoundException(
+    public Post updatePost(Long postId, UserAccountDTO userAccountDTO,
+        PostDTO postDTO, List<MultipartFile> postImageFiles,
+        Set<String> tagNames) {
+        Post post = postRepository.findByPostIdWithAll(postId).orElseThrow(() -> new PostNotFoundException(
             ErrorCode.POST_NOT_FOUND));
         if (!post.getUserAccount().getUsername().equals(userAccountDTO.username())) {
             throw new ForbiddenException(ErrorCode.FORBIDDEN);
         }
         post.updateTitleAndContent(postDTO.title(), postDTO.content());
+
+        Set<Tag> tags =
+            tagNames.isEmpty() ? Collections.emptySet() : tagNames.stream().map(Tag::of).collect(
+                Collectors.toUnmodifiableSet());
+        post.addTags(tags);
 
         List<Long> postImageIds = postDTO.postImageIds();
         if (postImageFiles != null) {
@@ -90,7 +84,7 @@ public class PostService {
             }
         }
 
-        return PostDTO.from(post);
+        return post;
     }
 
 

--- a/src/main/java/me/honki12345/hoonlog/service/TagService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/TagService.java
@@ -6,6 +6,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import me.honki12345.hoonlog.domain.Tag;
 import me.honki12345.hoonlog.dto.TagDTO;
+import me.honki12345.hoonlog.error.ErrorCode;
+import me.honki12345.hoonlog.error.exception.domain.TagNotFoundException;
 import me.honki12345.hoonlog.repository.TagRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,10 +19,12 @@ public class TagService {
 
     private final TagRepository tagRepository;
 
-    public Set<TagDTO> saveTags(Set<TagDTO> tagDTOs) {
-        Set<Tag> tags = tagDTOs.stream().map(TagDTO::toEntity)
-            .collect(Collectors.toUnmodifiableSet());
-        return tags.stream().map(tagRepository::save).map(TagDTO::fromWithoutPostIds)
-            .collect(Collectors.toUnmodifiableSet());
+    public Tag searchTag(String tagName) {
+        return tagRepository.findByName(tagName)
+            .orElseThrow(() -> new TagNotFoundException(ErrorCode.TAG_NOT_FOUND));
+    }
+
+    public Tag getTagIfPresent(String tagName) {
+        return tagRepository.findByName(tagName).orElse(Tag.of(tagName));
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/service/TagService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/TagService.java
@@ -1,0 +1,26 @@
+package me.honki12345.hoonlog.service;
+
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import me.honki12345.hoonlog.domain.Tag;
+import me.honki12345.hoonlog.dto.TagDTO;
+import me.honki12345.hoonlog.repository.TagRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    public Set<TagDTO> saveTags(Set<TagDTO> tagDTOs) {
+        Set<Tag> tags = tagDTOs.stream().map(TagDTO::toEntity)
+            .collect(Collectors.toUnmodifiableSet());
+        return tags.stream().map(tagRepository::save).map(TagDTO::fromWithoutPostIds)
+            .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/src/test/java/me/honki12345/hoonlog/service/PostCommentServiceTest.java
+++ b/src/test/java/me/honki12345/hoonlog/service/PostCommentServiceTest.java
@@ -59,7 +59,7 @@ class PostCommentServiceTest {
             postCommentRequest.toDTO(), post.getId(), userAccountDTO);
 
         // then
-        assertThat(postCommentDTO.postDTO().id()).isEqualTo(post.getId());
+        assertThat(postCommentDTO.id()).isEqualTo(post.getId());
         assertThat(postCommentDTO.createdBy()).isEqualTo(userAccountDTO.username());
         assertThat(postCommentDTO.content()).isEqualTo(TestUtil.TEST_COMMENT_CONTENT);
     }
@@ -80,7 +80,7 @@ class PostCommentServiceTest {
             userAccountDTO);
 
         // then
-        assertThat(savedPostCommentDTO.postDTO().id()).isEqualTo(post.getId());
+        assertThat(savedPostCommentDTO.id()).isEqualTo(post.getId());
         assertThat(savedPostCommentDTO.createdBy()).isEqualTo(userAccountDTO.username());
         assertThat(savedPostCommentDTO.content()).isEqualTo(updatedContent);
     }

--- a/src/test/java/me/honki12345/hoonlog/util/TestUtil.java
+++ b/src/test/java/me/honki12345/hoonlog/util/TestUtil.java
@@ -1,9 +1,13 @@
 package me.honki12345.hoonlog.util;
 
+import java.io.File;
 import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
 import lombok.RequiredArgsConstructor;
 import me.honki12345.hoonlog.domain.Post;
 import me.honki12345.hoonlog.domain.PostComment;
+import me.honki12345.hoonlog.domain.Tag;
 import me.honki12345.hoonlog.domain.UserAccount;
 import me.honki12345.hoonlog.dto.ProfileDTO;
 import me.honki12345.hoonlog.dto.TokenDTO;
@@ -18,10 +22,12 @@ import me.honki12345.hoonlog.repository.PostCommentRepository;
 import me.honki12345.hoonlog.repository.PostImageRepository;
 import me.honki12345.hoonlog.repository.PostRepository;
 import me.honki12345.hoonlog.repository.RefreshTokenRepository;
+import me.honki12345.hoonlog.repository.TagRepository;
 import me.honki12345.hoonlog.repository.UserAccountRepository;
 import me.honki12345.hoonlog.service.AuthService;
 import me.honki12345.hoonlog.service.UserAccountService;
 import org.springframework.boot.test.context.TestComponent;
+import org.springframework.transaction.annotation.Transactional;
 
 @TestComponent
 @RequiredArgsConstructor
@@ -34,6 +40,8 @@ public class TestUtil {
     public static final String TEST_UPDATED_POST_TITLE = "updatedTitle";
     public static final String TEST_UPDATED_POST_CONTENT = "updatedContent";
     public static final String TEST_COMMENT_CONTENT = "commentContent";
+    public static final String TEST_TAG_NAME = "tagName";
+    public static final String TEST_FILE_ORIGINAL_NAME = "drawing.jpg";
 
     private final AuthService authService;
     private final UserAccountService userAccountService;
@@ -43,13 +51,15 @@ public class TestUtil {
     private final UserAccountRepository userAccountRepository;
     private final PostCommentRepository postCommentRepository;
     private final PostImageRepository postImageRepository;
+    private final TagRepository tagRepository;
 
     public void deleteAllInBatchInAllRepository() {
-        postImageRepository.deleteAllInBatch();
+        this.postImageRepository.deleteAllInBatch();
         this.postCommentRepository.deleteAllInBatch();
         this.postRepository.deleteAllInBatch();
         this.refreshTokenRepository.deleteAllInBatch();
         this.userAccountRepository.deleteAllInBatch();
+        this.tagRepository.deleteAllInBatch();
     }
 
     public TokenDTO createTokensAfterSavingTestUser() {
@@ -87,7 +97,7 @@ public class TestUtil {
     }
 
     public Post createPostWithTestUser() {
-        PostRequest postRequest = new PostRequest(TEST_POST_TITLE, TEST_POST_CONTENT, null);
+        PostRequest postRequest = PostRequest.of(TEST_POST_TITLE, TEST_POST_CONTENT);
         Optional<UserAccount> optionalUserAccount = userAccountRepository.findByUsername(
             TEST_USERNAME);
         return optionalUserAccount.map(userAccount -> postRepository.saveAndFlush(
@@ -95,7 +105,7 @@ public class TestUtil {
     }
 
     public Post createPostWithTestUser(String title, String content) {
-        PostRequest postRequest = new PostRequest(title, content, null);
+        PostRequest postRequest = PostRequest.of(title, content);
         Optional<UserAccount> optionalUserAccount = userAccountRepository.findByUsername(
             TEST_USERNAME);
         return optionalUserAccount.map(userAccount -> postRepository.save(
@@ -115,5 +125,21 @@ public class TestUtil {
         postComment.addPost(post);
         postComment.addUserAccount(userAccount);
         return postCommentRepository.save(postComment);
+    }
+
+    @Transactional
+    public Tag createTagWithTestUser(Post post) {
+        Post findPost = postRepository.findById(post.getId())
+            .orElseThrow(() -> new PostNotFoundException(ErrorCode.POST_NOT_FOUND));
+        Tag tag = Tag.of(TEST_TAG_NAME);
+        findPost.addTags(Set.of(tag));
+        return tagRepository.save(tag);
+    }
+
+    public String createImageFilePath() {
+        StringJoiner sj = new StringJoiner(File.separator);
+        String pathname = System.getProperty("user.dir") + File.separator + "src";
+        return sj.add(pathname).add("test").add("data").add(TEST_FILE_ORIGINAL_NAME)
+            .toString();
     }
 }


### PR DESCRIPTION
태그 엔티티를 추가하고 게시물과 태그가 다대다 관계를 맺도록 하였다

---

- 저장된 게시물에서 태그수정 전략  
  1. 게시물의 기존 태그들에서 해당 게시물을 지운다.
  2. 해당 게시물에 새로운 태그들을 저장한다.
  3. 새로운 태그들에 해당 게시물을 추가한다.

- 태그 조회는 querydsl 을 통해 구현하였고, 테스트는 일정관계상 postman 을 통해 하였다