### PR TITLE
게시물 좋아요 기능구현

### DIFF
--- a/src/main/java/me/honki12345/hoonlog/config/SecurityConfig.java
+++ b/src/main/java/me/honki12345/hoonlog/config/SecurityConfig.java
@@ -43,6 +43,8 @@ public class SecurityConfig {
                 .requestMatchers(antMatcher(HttpMethod.PUT, "/api/v1/posts/{\\d+}")).authenticated()
                 .requestMatchers(antMatcher(HttpMethod.DELETE, "/api/v1/posts/{\\d+}")).authenticated()
                 .requestMatchers(antMatcher(HttpMethod.POST, "/api/v1/comments}")).authenticated()
+                .requestMatchers(antMatcher(HttpMethod.POST, "/api/v1/posts/like}")).authenticated()
+                .requestMatchers(antMatcher(HttpMethod.DELETE, "/api/v1/posts/like}")).authenticated()
                 .anyRequest().permitAll())
             .exceptionHandling(
                 configurer -> configurer.authenticationEntryPoint(customAuthenticationEntryPoint))

--- a/src/main/java/me/honki12345/hoonlog/controller/PostController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostController.java
@@ -44,14 +44,14 @@ public class PostController {
     @GetMapping
     public ResponseEntity<Page<PostResponse>> searchPosts(
         @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
-        Page<PostResponse> responses = postService.searchPostsByTagName(pageable)
+        Page<PostResponse> responses = postService.searchPosts(pageable)
             .map(PostResponse::from);
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }
 
-    @GetMapping("/tag/{tagName}")
+    @GetMapping("/tag")
     public ResponseEntity<Page<PostResponse>> searchPostsByTag(
-        @PathVariable String tagName,
+        @RequestParam("tagName") String tagName,
         @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
         TagDTO tagDTO = TagDTO.fromWithoutPostIds(tagService.searchTag(tagName));
         Page<PostResponse> responses = postService.searchPostsByTagName(pageable, tagDTO)
@@ -72,7 +72,6 @@ public class PostController {
                 postRequest.tagNames(),
                 userAccountPrincipal.toDTO()));
 
-        System.out.println(response);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 

--- a/src/main/java/me/honki12345/hoonlog/controller/PostLikeController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostLikeController.java
@@ -1,0 +1,37 @@
+package me.honki12345.hoonlog.controller;
+
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import me.honki12345.hoonlog.dto.PostLikeDTO;
+import me.honki12345.hoonlog.service.PostLikeService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts/like")
+@RestController
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+
+    @PostMapping
+    public ResponseEntity<Object> create(
+        @Valid @RequestBody PostLikeDTO postLikeDTO) {
+        postLikeService.create(postLikeDTO);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Object> delete(
+        @Valid @RequestBody PostLikeDTO postLikeDTO
+    ) {
+        postLikeService.delete(postLikeDTO);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/domain/Post.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/Post.java
@@ -20,10 +20,8 @@ import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import me.honki12345.hoonlog.domain.vo.AuditingFields;
 
-@ToString(callSuper = true)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -44,16 +42,13 @@ public class Post extends AuditingFields {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @ToString.Exclude
     @OrderBy("createdAt DESC")
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private final Set<PostComment> postComments = new LinkedHashSet<>();
 
-    @ToString.Exclude
     @OneToMany(mappedBy = "post")
     private List<PostImage> postImages = new LinkedList<>();
 
-    @ToString.Exclude
     @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinTable(
         name = "post_tag",
@@ -61,6 +56,9 @@ public class Post extends AuditingFields {
         inverseJoinColumns = @JoinColumn(name = "tagId")
     )
     private Set<Tag> tags = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "post")
+    private Set<PostLike> postLikes = new LinkedHashSet<>();
 
     private Post(Long id, UserAccount userAccount, String title, String content) {
         this.id = id;
@@ -149,4 +147,7 @@ public class Post extends AuditingFields {
         return this;
     }
 
+    public void deletePostLike(Post post) {
+        this.postLikes.remove(post);
+    }
 }

--- a/src/main/java/me/honki12345/hoonlog/domain/PostImage.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/PostImage.java
@@ -11,7 +11,6 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import me.honki12345.hoonlog.domain.vo.AuditingFields;
 
 @Getter

--- a/src/main/java/me/honki12345/hoonlog/domain/PostLike.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/PostLike.java
@@ -1,0 +1,75 @@
+package me.honki12345.hoonlog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.honki12345.hoonlog.domain.vo.AuditingFields;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class PostLike extends AuditingFields {
+
+    @Id
+    @Column(name = "post_like_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private UserAccount userAccount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "postId")
+    private Post post;
+
+    private PostLike(UserAccount userAccount, Post post) {
+        this.userAccount = userAccount;
+        this.post = post;
+    }
+
+    public static PostLike of(UserAccount userAccount, Post post) {
+        return new PostLike(userAccount, post);
+    }
+
+    public static PostLike emptyPostLike() {
+        return new PostLike(null, null);
+    }
+
+    public PostLike addUserAccount(UserAccount userAccount) {
+        this.userAccount = userAccount;
+        userAccount.getPostLikes().add(this);
+        return this;
+    }
+
+    public PostLike addPost(Post post) {
+        this.post = post;
+        post.getPostLikes().add(this);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PostLike postLike)) {
+            return false;
+        }
+        return Objects.equals(id, postLike.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/domain/UserAccount.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/UserAccount.java
@@ -11,7 +11,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -59,6 +61,9 @@ public class UserAccount {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @OneToMany(mappedBy = "userAccount")
+    private Set<PostLike> postLikes = new LinkedHashSet<>();
+
     private UserAccount(Long id, String username, String userPassword, String email,
         Profile profile,
         LocalDateTime createdAt) {
@@ -90,5 +95,9 @@ public class UserAccount {
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    public void deletePostLike(PostLike postLike) {
+        this.postLikes.remove(postLike);
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/PostDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/PostDTO.java
@@ -13,13 +13,13 @@ public record PostDTO(
     Long userId,
     String title,
     String content,
+    Long likeCount,
     LocalDateTime createdAt,
     String createdBy,
     LocalDateTime modifiedAt,
     String modifiedBy,
     List<Long> postImageIds,
     Set<Long> tagIds
-
 ) {
 
     public static PostDTO from(Post entity) {
@@ -28,6 +28,7 @@ public record PostDTO(
             entity.getUserAccount().getId(),
             entity.getTitle(),
             entity.getContent(),
+            (long) entity.getPostLikes().size(),
             entity.getCreatedAt(),
             entity.getCreatedBy(),
             entity.getModifiedAt(),
@@ -38,22 +39,11 @@ public record PostDTO(
     }
 
     public static PostDTO of(String title, String content, List<Long> postImageIds) {
-        return PostDTO.of(title, content, postImageIds, null);
-    }
-
-    public static PostDTO of(String title, String content, List<Long> postImageIds,
-        Set<Long> tagIds) {
-        return new PostDTO(null, null, title, content, null, null, null, null,  postImageIds,
-            tagIds);
+        return new PostDTO(null, null, title, content, null, null, null, null, null, postImageIds,
+            null);
     }
 
     public Post toEntity() {
         return Post.of(id, title, content);
-    }
-
-    public PostDTO addPostImageDTOs(List<PostImageDTO> dtos) {
-        return new PostDTO(this.id, this.userId, this.title, this.content, this.createdAt,
-            this.createdBy, this.modifiedAt, this.modifiedBy, this.postImageIds,
-            this.tagIds);
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/dto/PostLikeDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/PostLikeDTO.java
@@ -1,0 +1,8 @@
+package me.honki12345.hoonlog.dto;
+
+public record PostLikeDTO(
+    Long postId,
+    Long userId
+) {
+
+}

--- a/src/main/java/me/honki12345/hoonlog/dto/response/PostResponse.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/response/PostResponse.java
@@ -14,6 +14,7 @@ public record PostResponse(
     String title,
     String content,
     String createdBy,
+    Long likeCount,
     LocalDateTime createdAt,
     List<PostImageDTO> postImageDTOs,
     Set<PostCommentDTO> postCommentDTOs,
@@ -28,6 +29,7 @@ public record PostResponse(
             postDTO.title(),
             postDTO.content(),
             postDTO.createdBy(),
+            postDTO.likeCount(),
             postDTO.createdAt(),
             postImageDTOs,
             postCommentDTOs,
@@ -37,7 +39,7 @@ public record PostResponse(
 
     public static PostResponse from(PostDTO post) {
         return new PostResponse(post.id(), post.title(), post.content(), post.createdBy(),
-            post.createdAt(), null, null, null);
+            post.likeCount(), post.createdAt(), null, null, null);
     }
 
 

--- a/src/main/java/me/honki12345/hoonlog/error/ErrorCode.java
+++ b/src/main/java/me/honki12345/hoonlog/error/ErrorCode.java
@@ -31,7 +31,10 @@ public enum ErrorCode {
     IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "IMAGE1", "파일 업로드에 실패하였습니다"),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE2", "파일을 찾을 수 없습니다"),
 
-    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "TAG1", "태그를 찾을 수 없습니다");
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "TAG1", "태그를 찾을 수 없습니다"),
+
+    DUPLICATE_POST_LIKE(HttpStatus.BAD_REQUEST, "LIKE1", "이미 좋아요를 하셨습니다"),
+    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "LIKE2", "좋아요를 취소에 실패했습니다");
 
     private final String message;
     private final String code;

--- a/src/main/java/me/honki12345/hoonlog/error/GlobalExceptionHandler.java
+++ b/src/main/java/me/honki12345/hoonlog/error/GlobalExceptionHandler.java
@@ -2,17 +2,13 @@ package me.honki12345.hoonlog.error;
 
 import lombok.extern.slf4j.Slf4j;
 import me.honki12345.hoonlog.error.exception.CustomBaseException;
-import me.honki12345.hoonlog.error.exception.domain.DuplicateUserAccountException;
+import me.honki12345.hoonlog.error.exception.DuplicateException;
 import me.honki12345.hoonlog.error.exception.ForbiddenException;
 import me.honki12345.hoonlog.error.exception.domain.ImageUploadFailException;
-import me.honki12345.hoonlog.error.exception.domain.PostCommentNotFoundException;
-import me.honki12345.hoonlog.error.exception.domain.PostNotFoundException;
 import me.honki12345.hoonlog.error.exception.security.JwtException;
 import me.honki12345.hoonlog.error.exception.security.LoginErrorException;
 import me.honki12345.hoonlog.error.exception.security.LogoutErrorException;
 import me.honki12345.hoonlog.error.exception.NotFoundException;
-import me.honki12345.hoonlog.error.exception.domain.RoleNotFoundException;
-import me.honki12345.hoonlog.error.exception.domain.UserAccountNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -37,9 +33,9 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, ErrorCode.INVALID_INPUT_VALUE.getStatus());
     }
 
-    @ExceptionHandler(DuplicateUserAccountException.class)
+    @ExceptionHandler(DuplicateException.class)
     public ResponseEntity<ErrorResponse> handleDuplicationException(
-        DuplicateUserAccountException exception) {
+        DuplicateException exception) {
         return createResponseEntityByException(exception);
     }
 

--- a/src/main/java/me/honki12345/hoonlog/error/exception/DuplicateException.java
+++ b/src/main/java/me/honki12345/hoonlog/error/exception/DuplicateException.java
@@ -1,0 +1,10 @@
+package me.honki12345.hoonlog.error.exception;
+
+import me.honki12345.hoonlog.error.ErrorCode;
+
+public class DuplicateException extends CustomBaseException {
+
+    public DuplicateException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/error/exception/domain/DuplicatePostLikeException.java
+++ b/src/main/java/me/honki12345/hoonlog/error/exception/domain/DuplicatePostLikeException.java
@@ -1,12 +1,11 @@
 package me.honki12345.hoonlog.error.exception.domain;
 
 import me.honki12345.hoonlog.error.ErrorCode;
-import me.honki12345.hoonlog.error.exception.CustomBaseException;
 import me.honki12345.hoonlog.error.exception.DuplicateException;
 
-public class DuplicateUserAccountException extends DuplicateException {
+public class DuplicatePostLikeException extends DuplicateException {
 
-    public DuplicateUserAccountException(ErrorCode errorCode) {
+    public DuplicatePostLikeException(ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/error/exception/domain/PostLikeNotFoundException.java
+++ b/src/main/java/me/honki12345/hoonlog/error/exception/domain/PostLikeNotFoundException.java
@@ -1,0 +1,11 @@
+package me.honki12345.hoonlog.error.exception.domain;
+
+import me.honki12345.hoonlog.error.ErrorCode;
+import me.honki12345.hoonlog.error.exception.NotFoundException;
+
+public class PostLikeNotFoundException extends NotFoundException {
+
+    public PostLikeNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/repository/PostLikeRepository.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/PostLikeRepository.java
@@ -1,0 +1,11 @@
+package me.honki12345.hoonlog.repository;
+
+import java.util.Optional;
+import me.honki12345.hoonlog.domain.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    boolean existsByPost_IdAndUserAccount_Id(Long postId, Long userId);
+    Optional<PostLike> findByPost_IdAndUserAccount_Id(Long postId, Long userId);
+}

--- a/src/main/java/me/honki12345/hoonlog/repository/PostRepository.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/PostRepository.java
@@ -1,23 +1,8 @@
 package me.honki12345.hoonlog.repository;
 
-import java.util.Optional;
 import me.honki12345.hoonlog.domain.Post;
-import me.honki12345.hoonlog.domain.Tag;
 import me.honki12345.hoonlog.repository.querydsl.PostRepositoryCustom;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
-
-    @Query("SELECT p FROM Post p "
-        + "LEFT JOIN FETCH p.postImages LEFT JOIN FETCH p.postComments LEFT JOIN FETCH p.tags "
-        + "WHERE p.id = :postId")
-    Optional<Post> findByPostIdWithAll(@Param("postId") Long postId);
-
-    @Query("SELECT p FROM Post p "
-        + "LEFT JOIN FETCH p.postImages LEFT JOIN FETCH p.postComments LEFT JOIN FETCH p.tags")
-    Page<Post> findAllWithAll(Pageable pageable);
 }

--- a/src/main/java/me/honki12345/hoonlog/repository/UserAccountRepository.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/UserAccountRepository.java
@@ -1,11 +1,13 @@
 package me.honki12345.hoonlog.repository;
 
 import me.honki12345.hoonlog.domain.UserAccount;
+import me.honki12345.hoonlog.repository.querydsl.UserAccountRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long>,
+    UserAccountRepositoryCustom {
 
     Optional<UserAccount> findByUsername(String username);
 

--- a/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustom.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustom.java
@@ -1,11 +1,16 @@
 package me.honki12345.hoonlog.repository.querydsl;
 
+import java.util.Optional;
 import me.honki12345.hoonlog.domain.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepositoryCustom {
 
     Page<Post> findByTagName(String tagName, Pageable pageable);
+
+    Optional<Post> findByPostIdWithAll(@Param("postId") Long postId);
+    Page<Post> findAllWithAll(Pageable pageable);
 
 }

--- a/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustomImpl.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustomImpl.java
@@ -1,12 +1,16 @@
 package me.honki12345.hoonlog.repository.querydsl;
 
+import static me.honki12345.hoonlog.domain.QPost.*;
+import static me.honki12345.hoonlog.domain.QPostComment.*;
+import static me.honki12345.hoonlog.domain.QPostImage.*;
+import static me.honki12345.hoonlog.domain.QPostLike.*;
+import static me.honki12345.hoonlog.domain.QTag.*;
+
 import com.querydsl.jpa.JPQLQuery;
 import java.util.List;
+import java.util.Optional;
 import me.honki12345.hoonlog.domain.Post;
-import me.honki12345.hoonlog.domain.QPost;
-import me.honki12345.hoonlog.domain.QPostComment;
-import me.honki12345.hoonlog.domain.QPostImage;
-import me.honki12345.hoonlog.domain.QTag;
+import me.honki12345.hoonlog.domain.QPostLike;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -20,10 +24,6 @@ public class PostRepositoryCustomImpl extends QuerydslRepositorySupport implemen
 
     @Override
     public Page<Post> findByTagName(String tagName, Pageable pageable) {
-        QPost post = QPost.post;
-        QTag tag = QTag.tag;
-        QPostComment postComment = QPostComment.postComment;
-        QPostImage postImage = QPostImage.postImage;
 
         JPQLQuery<Post> query = from(post)
             .innerJoin(post.tags, tag).fetchJoin()
@@ -35,5 +35,28 @@ public class PostRepositoryCustomImpl extends QuerydslRepositorySupport implemen
         return new PageImpl<>(posts, pageable, query.fetchCount());
 
 
+    }
+
+    @Override
+    public Optional<Post> findByPostIdWithAll(Long postId) {
+        Post fetchedOne = from(post)
+            .leftJoin(post.postImages, postImage).fetchJoin()
+            .leftJoin(post.postComments, postComment).fetchJoin()
+            .leftJoin(post.tags, tag).fetchJoin()
+            .leftJoin(post.postLikes, postLike).fetchJoin()
+            .where(post.id.eq(postId))
+            .fetchOne();
+        return Optional.ofNullable(fetchedOne);
+    }
+
+    @Override
+    public Page<Post> findAllWithAll(Pageable pageable) {
+        JPQLQuery<Post> query = from(post)
+            .leftJoin(post.postImages, postImage).fetchJoin()
+            .leftJoin(post.postComments, postComment).fetchJoin()
+            .leftJoin(post.tags, tag).fetchJoin()
+            .leftJoin(post.postLikes, postLike).fetchJoin();
+        List<Post> posts = getQuerydsl().applyPagination(pageable, query).fetch();
+        return new PageImpl<>(posts, pageable, query.fetchCount());
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/repository/querydsl/UserAccountRepositoryCustom.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/querydsl/UserAccountRepositoryCustom.java
@@ -1,0 +1,9 @@
+package me.honki12345.hoonlog.repository.querydsl;
+
+import java.util.Optional;
+import me.honki12345.hoonlog.domain.UserAccount;
+
+public interface UserAccountRepositoryCustom {
+
+    Optional<UserAccount> findByIdWithPostLike(Long userId);
+}

--- a/src/main/java/me/honki12345/hoonlog/repository/querydsl/UserAccountRepositoryCustomImpl.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/querydsl/UserAccountRepositoryCustomImpl.java
@@ -1,0 +1,27 @@
+package me.honki12345.hoonlog.repository.querydsl;
+
+import static me.honki12345.hoonlog.domain.QPostLike.*;
+import static me.honki12345.hoonlog.domain.QUserAccount.*;
+
+import java.util.Optional;
+import me.honki12345.hoonlog.domain.QPostLike;
+import me.honki12345.hoonlog.domain.QUserAccount;
+import me.honki12345.hoonlog.domain.UserAccount;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+public class UserAccountRepositoryCustomImpl extends QuerydslRepositorySupport implements
+    UserAccountRepositoryCustom {
+
+    public UserAccountRepositoryCustomImpl() {
+        super(UserAccount.class);
+    }
+
+    @Override
+    public Optional<UserAccount> findByIdWithPostLike(Long userId) {
+        UserAccount fetchedOne = from(userAccount)
+            .leftJoin(userAccount.postLikes, postLike).fetchJoin()
+            .where(userAccount.id.eq(userId))
+            .fetchOne();
+        return Optional.ofNullable(fetchedOne);
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/service/PostLikeService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/PostLikeService.java
@@ -1,0 +1,57 @@
+package me.honki12345.hoonlog.service;
+
+import lombok.RequiredArgsConstructor;
+import me.honki12345.hoonlog.domain.Post;
+import me.honki12345.hoonlog.domain.PostLike;
+import me.honki12345.hoonlog.domain.UserAccount;
+import me.honki12345.hoonlog.dto.PostLikeDTO;
+import me.honki12345.hoonlog.error.ErrorCode;
+import me.honki12345.hoonlog.error.exception.domain.DuplicatePostLikeException;
+import me.honki12345.hoonlog.error.exception.domain.PostLikeNotFoundException;
+import me.honki12345.hoonlog.error.exception.domain.PostNotFoundException;
+import me.honki12345.hoonlog.error.exception.domain.UserAccountNotFoundException;
+import me.honki12345.hoonlog.repository.PostLikeRepository;
+import me.honki12345.hoonlog.repository.PostRepository;
+import me.honki12345.hoonlog.repository.UserAccountRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class PostLikeService {
+
+    private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
+    private final UserAccountRepository userAccountRepository;
+
+    public void create(PostLikeDTO postLikeDTO) {
+        UserAccount userAccount = userAccountRepository.findByIdWithPostLike(postLikeDTO.userId())
+            .orElseThrow(() -> new UserAccountNotFoundException(
+                ErrorCode.USER_ACCOUNT_NOT_FOUND));
+        Post post = postRepository.findByPostIdWithAll(postLikeDTO.postId())
+            .orElseThrow(() -> new PostNotFoundException(ErrorCode.POST_NOT_FOUND));
+        if (postLikeRepository.existsByPost_IdAndUserAccount_Id(postLikeDTO.postId(),
+            postLikeDTO.userId())) {
+            throw new DuplicatePostLikeException(ErrorCode.DUPLICATE_POST_LIKE);
+        }
+
+        PostLike postLike = PostLike.emptyPostLike();
+        postLike.addUserAccount(userAccount).addPost(post);
+        postLikeRepository.save(postLike);
+    }
+
+    public void delete(PostLikeDTO postLikeDTO) {
+        UserAccount userAccount = userAccountRepository.findByIdWithPostLike(postLikeDTO.userId())
+            .orElseThrow(() -> new UserAccountNotFoundException(
+                ErrorCode.USER_ACCOUNT_NOT_FOUND));
+        Post post = postRepository.findByPostIdWithAll(postLikeDTO.postId())
+            .orElseThrow(() -> new PostNotFoundException(ErrorCode.POST_NOT_FOUND));
+        PostLike postLike = postLikeRepository.findByPost_IdAndUserAccount_Id(postLikeDTO.postId(),
+                postLikeDTO.userId())
+            .orElseThrow(() -> new PostLikeNotFoundException(ErrorCode.POST_LIKE_NOT_FOUND));
+        userAccount.deletePostLike(postLike);
+        post.deletePostLike(post);
+        postLikeRepository.delete(postLike);
+    }
+}

--- a/src/main/java/me/honki12345/hoonlog/service/PostService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/PostService.java
@@ -42,7 +42,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Post> searchPostsByTagName(Pageable pageable) {
+    public Page<Post> searchPosts(Pageable pageable) {
         return postRepository.findAllWithAll(pageable);
     }
 
@@ -61,13 +61,14 @@ public class PostService {
 
         Post post = postDTO.toEntity();
         post.addUserAccount(userAccount);
+        postRepository.save(post);
         Optional.ofNullable(postImageFiles).ifPresent(
             multipartFiles -> postImageService.savePostImagesWithPost(postImageFiles, post));
         post.addTags(tagNames.isEmpty() ?
             Collections.emptySet() : tagNames.stream().map(tagService::getTagIfPresent).collect(
             Collectors.toUnmodifiableSet()));
 
-        return postRepository.save(post);
+        return post;
     }
 
     public Post updatePost(Long postId, UserAccountDTO userAccountDTO,

--- a/src/main/java/me/honki12345/hoonlog/service/TagService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/TagService.java
@@ -1,11 +1,8 @@
 package me.honki12345.hoonlog.service;
 
 
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import me.honki12345.hoonlog.domain.Tag;
-import me.honki12345.hoonlog.dto.TagDTO;
 import me.honki12345.hoonlog.error.ErrorCode;
 import me.honki12345.hoonlog.error.exception.domain.TagNotFoundException;
 import me.honki12345.hoonlog.repository.TagRepository;

--- a/src/test/java/me/honki12345/hoonlog/service/PostCommentServiceTest.java
+++ b/src/test/java/me/honki12345/hoonlog/service/PostCommentServiceTest.java
@@ -39,6 +39,8 @@ class PostCommentServiceTest {
     PostCommentRepository postCommentRepository;
     @Autowired
     PostCommentService postCommentService;
+    @Autowired
+    PostService postService;
 
     @AfterEach
     void tearDown() {


### PR DESCRIPTION
- 도메인 좋아요(PostLike)를 설계하고, 게시글(Post)와 다대일, 유저(UserAccount)와 다대일 관계를 맺었다.
- 좋아요 추가와 삭제 API 를 추가하고, 로그인한 사람만 할 수 있도록 SecurityConfig 설정을 추가하였다
- 좋아요 추가시 좋아요(PostLike) 객체를 생성한다.  
  게시글(Post)의 좋아요 컬렉션에 해당 좋아요를 추가하고, 유저(UserAccount)의 좋아요컬렉션에 해당 좋아요를 추가한다.
  만약 이미 존재하는 좋아요(PostLike) 가 있다면, 예외를 던진다
- 좋아요 삭제시 좋아요(PostLike) 객체를 삭제한다.  
  만약 좋아요(PostLike) 가 없다면, 예외를 던진다
  게시글(Post)의 좋아요 컬렉션에 해당 좋아요를 삭제하고, 유저(UserAccount)의 좋아요컬렉션에 해당 좋아요를 삭제한다.