### PR TITLE
게시물조회 (페이징네이션: 트렌딩순, 최신순)

### DIFF
--- a/src/main/java/me/honki12345/hoonlog/controller/PostController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostController.java
@@ -12,9 +12,7 @@ import me.honki12345.hoonlog.security.jwt.util.IfLogin;
 import me.honki12345.hoonlog.service.PostService;
 import me.honki12345.hoonlog.service.TagService;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -34,6 +32,8 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 public class PostController {
 
+    public static final int PAGEABLE_DEFAULT_SIZE = 10;
+    public static final String PAGEABLE_DEFAULT_SORT_COLUMN = "createdAt";
     private final PostService postService;
     private final TagService tagService;
 
@@ -46,7 +46,7 @@ public class PostController {
     @GetMapping
     public ResponseEntity<Page<PostResponse>> searchPosts(
         @RequestParam(required = false) String searchKeyword,
-        @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+        @PageableDefault(size = PAGEABLE_DEFAULT_SIZE, sort = PAGEABLE_DEFAULT_SORT_COLUMN, direction = Direction.DESC) Pageable pageable) {
         Page<PostResponse> responses = postService.searchPosts(searchKeyword, pageable)
             .map(PostResponse::from);
         return new ResponseEntity<>(responses, HttpStatus.OK);
@@ -55,22 +55,12 @@ public class PostController {
     @GetMapping("/tag")
     public ResponseEntity<Page<PostResponse>> searchPostsByTag(
         @RequestParam("tagName") String tagName,
-        @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+        @PageableDefault(size = PAGEABLE_DEFAULT_SIZE, sort = PAGEABLE_DEFAULT_SORT_COLUMN, direction = Direction.DESC) Pageable pageable) {
         TagDTO tagDTO = TagDTO.fromWithoutPostIds(tagService.searchTag(tagName));
         Page<PostResponse> responses = postService.searchPostsByTagName(pageable, tagDTO)
             .map(PostResponse::from);
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }
-
-    @GetMapping("/trending")
-    public ResponseEntity<Page<PostResponse>> searchPostsOrderByTrending() {
-        Pageable pageable = PageRequest.of(0, 10,
-            Sort.by("likeCount", "createdAt").descending());
-        Page<PostResponse> responses = postService.searchPosts(null, pageable)
-            .map(PostResponse::from);
-        return new ResponseEntity<>(responses, HttpStatus.OK);
-    }
-
 
     @PostMapping
     public ResponseEntity<PostResponse> addPost(

--- a/src/main/java/me/honki12345/hoonlog/controller/PostController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostController.java
@@ -45,8 +45,9 @@ public class PostController {
 
     @GetMapping
     public ResponseEntity<Page<PostResponse>> searchPosts(
+        @RequestParam(required = false) String searchKeyword,
         @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
-        Page<PostResponse> responses = postService.searchPosts(pageable)
+        Page<PostResponse> responses = postService.searchPosts(searchKeyword, pageable)
             .map(PostResponse::from);
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }
@@ -65,7 +66,7 @@ public class PostController {
     public ResponseEntity<Page<PostResponse>> searchPostsOrderByTrending() {
         Pageable pageable = PageRequest.of(0, 10,
             Sort.by("likeCount", "createdAt").descending());
-        Page<PostResponse> responses = postService.searchPosts(pageable)
+        Page<PostResponse> responses = postService.searchPosts(null, pageable)
             .map(PostResponse::from);
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }

--- a/src/main/java/me/honki12345/hoonlog/controller/PostController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostController.java
@@ -12,7 +12,9 @@ import me.honki12345.hoonlog.security.jwt.util.IfLogin;
 import me.honki12345.hoonlog.service.PostService;
 import me.honki12345.hoonlog.service.TagService;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -55,6 +57,15 @@ public class PostController {
         @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
         TagDTO tagDTO = TagDTO.fromWithoutPostIds(tagService.searchTag(tagName));
         Page<PostResponse> responses = postService.searchPostsByTagName(pageable, tagDTO)
+            .map(PostResponse::from);
+        return new ResponseEntity<>(responses, HttpStatus.OK);
+    }
+
+    @GetMapping("/trending")
+    public ResponseEntity<Page<PostResponse>> searchPostsOrderByTrending() {
+        Pageable pageable = PageRequest.of(0, 10,
+            Sort.by("likeCount", "createdAt").descending());
+        Page<PostResponse> responses = postService.searchPosts(pageable)
             .map(PostResponse::from);
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }

--- a/src/main/java/me/honki12345/hoonlog/domain/PostLike.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/PostLike.java
@@ -45,18 +45,6 @@ public class PostLike extends AuditingFields {
         return new PostLike(null, null);
     }
 
-    public PostLike addUserAccount(UserAccount userAccount) {
-        this.userAccount = userAccount;
-        userAccount.getPostLikes().add(this);
-        return this;
-    }
-
-    public PostLike addPost(Post post) {
-        this.post = post;
-        post.getPostLikes().add(this);
-        return this;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -71,5 +59,13 @@ public class PostLike extends AuditingFields {
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    public void addPost(Post post) {
+        this.post = post;
+    }
+
+    public void addUserAccount(UserAccount userAccount) {
+        this.userAccount = userAccount;
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/domain/UserAccount.java
+++ b/src/main/java/me/honki12345/hoonlog/domain/UserAccount.java
@@ -97,6 +97,11 @@ public class UserAccount {
         return Objects.hash(id);
     }
 
+    public void addPostLike(PostLike postLike) {
+        this.postLikes.add(postLike);
+        postLike.addUserAccount(this);
+    }
+
     public void deletePostLike(PostLike postLike) {
         this.postLikes.remove(postLike);
     }

--- a/src/main/java/me/honki12345/hoonlog/dto/PostDTO.java
+++ b/src/main/java/me/honki12345/hoonlog/dto/PostDTO.java
@@ -28,7 +28,7 @@ public record PostDTO(
             entity.getUserAccount().getId(),
             entity.getTitle(),
             entity.getContent(),
-            (long) entity.getPostLikes().size(),
+            entity.getLikeCount(),
             entity.getCreatedAt(),
             entity.getCreatedBy(),
             entity.getModifiedAt(),

--- a/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustom.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustom.java
@@ -12,5 +12,6 @@ public interface PostRepositoryCustom {
 
     Optional<Post> findByPostIdWithAll(@Param("postId") Long postId);
     Page<Post> findAllWithAll(Pageable pageable);
+    Page<Post> findWithAllByTitleContainingOrContentContaining(String keyword, Pageable pageable);
 
 }

--- a/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustomImpl.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustomImpl.java
@@ -10,13 +10,13 @@ import com.querydsl.jpa.JPQLQuery;
 import java.util.List;
 import java.util.Optional;
 import me.honki12345.hoonlog.domain.Post;
-import me.honki12345.hoonlog.domain.QPostLike;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
-public class PostRepositoryCustomImpl extends QuerydslRepositorySupport implements PostRepositoryCustom {
+public class PostRepositoryCustomImpl extends QuerydslRepositorySupport implements
+    PostRepositoryCustom {
 
     public PostRepositoryCustomImpl() {
         super(Post.class);
@@ -56,6 +56,19 @@ public class PostRepositoryCustomImpl extends QuerydslRepositorySupport implemen
             .leftJoin(post.postComments, postComment).fetchJoin()
             .leftJoin(post.tags, tag).fetchJoin()
             .leftJoin(post.postLikes, postLike).fetchJoin();
+        List<Post> posts = getQuerydsl().applyPagination(pageable, query).fetch();
+        return new PageImpl<>(posts, pageable, query.fetchCount());
+    }
+
+    @Override
+    public Page<Post> findWithAllByTitleContainingOrContentContaining(String keyword,
+        Pageable pageable) {
+        JPQLQuery<Post> query = from(post)
+            .leftJoin(post.postImages, postImage).fetchJoin()
+            .leftJoin(post.postComments, postComment).fetchJoin()
+            .leftJoin(post.tags, tag).fetchJoin()
+            .leftJoin(post.postLikes, postLike).fetchJoin()
+            .where(post.title.contains(keyword).or(post.content.contains(keyword)));
         List<Post> posts = getQuerydsl().applyPagination(pageable, query).fetch();
         return new PageImpl<>(posts, pageable, query.fetchCount());
     }

--- a/src/main/java/me/honki12345/hoonlog/service/PostLikeService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/PostLikeService.java
@@ -37,7 +37,8 @@ public class PostLikeService {
         }
 
         PostLike postLike = PostLike.emptyPostLike();
-        postLike.addUserAccount(userAccount).addPost(post);
+        userAccount.addPostLike(postLike);
+        post.addPostLike(postLike);
         postLikeRepository.save(postLike);
     }
 
@@ -51,7 +52,7 @@ public class PostLikeService {
                 postLikeDTO.userId())
             .orElseThrow(() -> new PostLikeNotFoundException(ErrorCode.POST_LIKE_NOT_FOUND));
         userAccount.deletePostLike(postLike);
-        post.deletePostLike(post);
+        post.deletePostLike(postLike);
         postLikeRepository.delete(postLike);
     }
 }

--- a/src/main/java/me/honki12345/hoonlog/service/PostService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/PostService.java
@@ -42,8 +42,13 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Post> searchPosts(Pageable pageable) {
-        return postRepository.findAllWithAll(pageable);
+    public Page<Post> searchPosts(String searchKeyword, Pageable pageable) {
+        if (searchKeyword == null || searchKeyword.isBlank()) {
+            return postRepository.findAllWithAll(pageable);
+        }
+
+        return postRepository.findWithAllByTitleContainingOrContentContaining(searchKeyword,
+            pageable);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/hoonlog
     username: fpg123
-    password: password
+    password: 12345678
   jpa:
     defer-datasource-initialization: true
     hibernate:


### PR DESCRIPTION
게시물 조회에서 트렌딩순과 최신순으로 하는 페이징네이션을 구현하였다.

---

- 최신순은 `Pageable` 객체의 속성에서 sort 를 `createdAt`, direction 를 `Direction.DESC`로 설정하여 기본 검색으로 구현하였다.
- 트렌딩순은 `Pageable` 객체의 속성에서 `Sort` 객체를 `likeCount`, `createdAt`, `descending()` 으로 구현하였다.
- 게시물(Post) 를 `likeCount` 으로 정렬하기 위해 게시물 속성에 `likeCount`를 추가하였고
  동시성이슈를 고려하여 게시물(Post)이 가지고 있는 좋아요컬렉션(postLikes)을 `ConcurrentSkipListSet` 으로 구현하였고
  좋아요카운트를 컬렉션의 `count()` 을 이용하도록 구현하였다.
- 일정 때문에 테스트는 postman 으로 진행하였고 추후에 추가할 예정