### PR TITLE
 게시물검색 (키워드기반)

### DIFF
--- a/src/main/java/me/honki12345/hoonlog/controller/PostController.java
+++ b/src/main/java/me/honki12345/hoonlog/controller/PostController.java
@@ -45,8 +45,9 @@ public class PostController {
 
     @GetMapping
     public ResponseEntity<Page<PostResponse>> searchPosts(
+        @RequestParam(required = false) String searchKeyword,
         @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
-        Page<PostResponse> responses = postService.searchPosts(pageable)
+        Page<PostResponse> responses = postService.searchPosts(searchKeyword, pageable)
             .map(PostResponse::from);
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }
@@ -65,7 +66,7 @@ public class PostController {
     public ResponseEntity<Page<PostResponse>> searchPostsOrderByTrending() {
         Pageable pageable = PageRequest.of(0, 10,
             Sort.by("likeCount", "createdAt").descending());
-        Page<PostResponse> responses = postService.searchPosts(pageable)
+        Page<PostResponse> responses = postService.searchPosts(null, pageable)
             .map(PostResponse::from);
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }

--- a/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustom.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustom.java
@@ -12,5 +12,6 @@ public interface PostRepositoryCustom {
 
     Optional<Post> findByPostIdWithAll(@Param("postId") Long postId);
     Page<Post> findAllWithAll(Pageable pageable);
+    Page<Post> findWithAllByTitleContainingOrContentContaining(String keyword, Pageable pageable);
 
 }

--- a/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustomImpl.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/querydsl/PostRepositoryCustomImpl.java
@@ -10,13 +10,13 @@ import com.querydsl.jpa.JPQLQuery;
 import java.util.List;
 import java.util.Optional;
 import me.honki12345.hoonlog.domain.Post;
-import me.honki12345.hoonlog.domain.QPostLike;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
-public class PostRepositoryCustomImpl extends QuerydslRepositorySupport implements PostRepositoryCustom {
+public class PostRepositoryCustomImpl extends QuerydslRepositorySupport implements
+    PostRepositoryCustom {
 
     public PostRepositoryCustomImpl() {
         super(Post.class);
@@ -56,6 +56,19 @@ public class PostRepositoryCustomImpl extends QuerydslRepositorySupport implemen
             .leftJoin(post.postComments, postComment).fetchJoin()
             .leftJoin(post.tags, tag).fetchJoin()
             .leftJoin(post.postLikes, postLike).fetchJoin();
+        List<Post> posts = getQuerydsl().applyPagination(pageable, query).fetch();
+        return new PageImpl<>(posts, pageable, query.fetchCount());
+    }
+
+    @Override
+    public Page<Post> findWithAllByTitleContainingOrContentContaining(String keyword,
+        Pageable pageable) {
+        JPQLQuery<Post> query = from(post)
+            .leftJoin(post.postImages, postImage).fetchJoin()
+            .leftJoin(post.postComments, postComment).fetchJoin()
+            .leftJoin(post.tags, tag).fetchJoin()
+            .leftJoin(post.postLikes, postLike).fetchJoin()
+            .where(post.title.contains(keyword).or(post.content.contains(keyword)));
         List<Post> posts = getQuerydsl().applyPagination(pageable, query).fetch();
         return new PageImpl<>(posts, pageable, query.fetchCount());
     }

--- a/src/main/java/me/honki12345/hoonlog/service/PostService.java
+++ b/src/main/java/me/honki12345/hoonlog/service/PostService.java
@@ -42,8 +42,13 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Post> searchPosts(Pageable pageable) {
-        return postRepository.findAllWithAll(pageable);
+    public Page<Post> searchPosts(String searchKeyword, Pageable pageable) {
+        if (searchKeyword == null || searchKeyword.isBlank()) {
+            return postRepository.findAllWithAll(pageable);
+        }
+
+        return postRepository.findWithAllByTitleContainingOrContentContaining(searchKeyword,
+            pageable);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
- 키워드를 기반으로 게시물의 제목 또는 내용을 포함하고 있는 게시물을 검색합니다.
- querldsl 에서 `where(title.contains(keyword).or.(content.contains(keyword))` 을 사용하였기 때문에
  `%keyword%` 로 DB에 쿼리가 나가 성능면에서 최적화를 추후에 할 예정입니다.
- 테스트는 postman 을 하여 수동테스트를 하였으나 통합테스트 같은 자동테스트도 추후에 구현할 예정입니다