### PR TITLE
elasticsearch client 버전 낮추기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     // elasticsearch
-    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
     testImplementation "org.testcontainers:elasticsearch:1.16.3"
     // queryDSL 설정
     // querydsl

--- a/es.yml
+++ b/es.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     container_name: es
     environment:
       - node.name=single-node
@@ -15,7 +15,7 @@ services:
 
   kibana:
     container_name: kibana
-    image: docker.elastic.co/kibana/kibana:7.15.2
+    image: docker.elastic.co/kibana/kibana:7.10.2
     environment:
       SERVER_NAME: kibana
       ELASTICSEARCH_HOSTS: http://es:9200

--- a/src/main/java/me/honki12345/hoonlog/config/ElasticSearchConfig.java
+++ b/src/main/java/me/honki12345/hoonlog/config/ElasticSearchConfig.java
@@ -36,11 +36,20 @@ public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
 
     @Override
     public RestHighLevelClient elasticsearchClient() {
-        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
-            .connectedTo(new InetSocketAddress(host, Integer.valueOf(port)))
-            .usingSsl()
-            .withBasicAuth(username, password)
-            .build();
+        String profile = System.getProperty("spring.profiles.active");
+
+        ClientConfiguration clientConfiguration;
+        if ("dev".equals(profile) || "test".equals(profile)) {
+            clientConfiguration = ClientConfiguration.builder()
+                .connectedTo(new InetSocketAddress(host, Integer.valueOf(port)))
+                .build();
+        } else {
+            clientConfiguration = ClientConfiguration.builder()
+                .connectedTo(new InetSocketAddress(host, Integer.valueOf(port)))
+                .usingSsl()
+                .withBasicAuth(username, password)
+                .build();
+        }
         return RestClients.create(clientConfiguration).rest();
     }
 

--- a/src/main/java/me/honki12345/hoonlog/config/ElasticSearchConfig.java
+++ b/src/main/java/me/honki12345/hoonlog/config/ElasticSearchConfig.java
@@ -1,9 +1,11 @@
 package me.honki12345.hoonlog.config;
 
+import java.net.InetSocketAddress;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import me.honki12345.hoonlog.repository.elasticsearch.PostSearchRepository;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,22 +13,35 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
-import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchCustomConversions;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
 @EnableElasticsearchRepositories(basePackageClasses = {PostSearchRepository.class})
 @Configuration
-public class ElasticSearchConfig extends ElasticsearchConfiguration {
+public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
 
-    @Value("${elasticsearch.hostAndPort}")
-    private String hostAndPost;
+    @Value("${elasticsearch.host}")
+    private String host;
+
+    @Value("${elasticsearch.port}")
+    private String port;
+
+    @Value("${elasticsearch.username}")
+    private String username;
+
+    @Value("${elasticsearch.password}")
+    private String password;
 
     @Override
-    public ClientConfiguration clientConfiguration() {
-        return ClientConfiguration.builder()
-            .connectedTo(hostAndPost)
+    public RestHighLevelClient elasticsearchClient() {
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+            .connectedTo(new InetSocketAddress(host, Integer.valueOf(port)))
+            .usingSsl()
+            .withBasicAuth(username, password)
             .build();
+        return RestClients.create(clientConfiguration).rest();
     }
 
     @Bean

--- a/src/main/java/me/honki12345/hoonlog/config/Initializer.java
+++ b/src/main/java/me/honki12345/hoonlog/config/Initializer.java
@@ -34,6 +34,11 @@ public class Initializer {
 
     public static final String DEFAULT_ROLE_NAME = "ROLE_USER";
 
+    // total data count = COUNT * BULK_SIZE
+    public static final int COUNT = 50;
+    public static final int BULK_SIZE = 1_000;
+    public static final int THREAD_SIZE = 6;
+
     @Bean
     public CommandLineRunner init(RoleRepository roleRepository) {
 
@@ -88,13 +93,13 @@ public class Initializer {
             UserAccount savedUserAccount = userAccountRepository.save(userAccount);
             LocalDateTime time = LocalDateTime.now();
 
-            ExecutorService executorService = Executors.newFixedThreadPool(6);
-            CountDownLatch countDownLatch = new CountDownLatch(100);
-            for (int i = 1; i <= 100; i++) {
+            ExecutorService executorService = Executors.newFixedThreadPool(THREAD_SIZE);
+            CountDownLatch countDownLatch = new CountDownLatch(COUNT);
+            for (int i = 1; i <= COUNT; i++) {
                 int count = i;
                 executorService.execute(() -> {
                     List<Post> posts = new LinkedList<>();
-                    for (int j = 1 + (count - 1) * 10_000; j <= count * 10_000; j++) {
+                    for (int j = 1 + (count - 1) * BULK_SIZE; j <= count * BULK_SIZE; j++) {
                         Post post = Post.of((long) j, savedUserAccount, lorem.getTitle(3, 5),
                             lorem.getWords(5, 10));
                         post.updateTimeAndWriter(userAccount.getUsername(), time);

--- a/src/main/java/me/honki12345/hoonlog/repository/elasticsearch/PostSearchRepository.java
+++ b/src/main/java/me/honki12345/hoonlog/repository/elasticsearch/PostSearchRepository.java
@@ -1,5 +1,6 @@
 package me.honki12345.hoonlog.repository.elasticsearch;
 
+import java.util.List;
 import me.honki12345.hoonlog.domain.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -7,7 +8,11 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 
 public interface PostSearchRepository extends ElasticsearchRepository<Post, Long> {
 
-    public Page<Post> findByTitleContainingOrContentContaining(String title, String content,
+    Page<Post> findByTitleContainingOrContentContaining(String title, String content,
         Pageable pageable);
+
+    List<Post> saveAll(Iterable<Post> posts);
+    Post save(Post post);
+    void deleteAll();
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -95,3 +95,8 @@ file:
     url: /images/post/
   image:
     location: ${user.home}${file.separator}test-hoonlog${file.separator}post
+elasticsearch:
+  host: localhost
+  port: 8080
+  username: username
+  password: password

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,7 +60,10 @@ file:
   image:
     location: ${user.home}${file.separator}hoonlog${file.separator}post
 elasticsearch:
-  hostAndPort: localhost:9200
+  host: ${ES_HOST}
+  port: ${ES_PORT}
+  username: ${ES_USERNAME}
+  password: ${ES_PASSWORD}
 
 ---
 spring:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,10 +8,6 @@ logging:
     org.hibernate.type.descriptor.sql.BasicBinder: trace
     org.hibernate.orm.jdbc.bind: trace
 spring:
-  datasource:
-    url: ${LOCAL_DB_URL}
-    username: ${LOCAL_DB_USERNAME}
-    password: ${LOCAL_DB_PASSWORD}
   jpa:
     defer-datasource-initialization: true
     hibernate:
@@ -47,24 +43,51 @@ springdoc:
   default-produces-media-type: application/json
   paths-to-match:
     - /api/v1/**
-
-jwt:
-  secretKey: ${JWT_SECRET_KEY}
-  refreshKey: ${JWT_REFRESH_KEY}
-  access-token-expire-count: 1800000
-  refresh-token-expire-count: 604800000
 file:
   upload:
     location: ${user.home}${file.separator}hoonlog
     url: /images/post/
   image:
     location: ${user.home}${file.separator}hoonlog${file.separator}post
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
+jwt:
+  secretKey: ${JWT_SECRET_KEY}
+  refreshKey: ${JWT_REFRESH_KEY}
+  access-token-expire-count: 1800000
+  refresh-token-expire-count: 604800000
 elasticsearch:
   host: ${ES_HOST}
   port: ${ES_PORT}
   username: ${ES_USERNAME}
   password: ${ES_PASSWORD}
-
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
+jwt:
+  secretKey: ${JWT_SECRET_KEY}
+  refreshKey: ${JWT_REFRESH_KEY}
+  access-token-expire-count: 1800000
+  refresh-token-expire-count: 604800000
+elasticsearch:
+  host: localhost
+  port: 9200
+  username: username
+  password: password
 ---
 spring:
   config:
@@ -83,12 +106,11 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
-  h2:
-    console:
-      enabled: true
 jwt:
   secretKey: 098766543211hoon-log-secretKey-2023-10-0101234567890
   refreshKey: 2098766543211hoon023_10-01-hoon-log-refreshKey01234567890
+  access-token-expire-count: 1800000
+  refresh-token-expire-count: 604800000
 file:
   upload:
     location: ${user.home}${file.separator}test-hoonlog

--- a/src/test/java/me/honki12345/hoonlog/config/ElasticSearchConfigTest.java
+++ b/src/test/java/me/honki12345/hoonlog/config/ElasticSearchConfigTest.java
@@ -12,12 +12,23 @@ public class ElasticSearchConfigTest {
     void elasticSearchConfigTest() throws Exception {
         // given
         ElasticSearchConfig elasticSearchConfig = new ElasticSearchConfig();
-        Field hostAndPost = ElasticSearchConfig.class.getDeclaredField("hostAndPost");
-        hostAndPost.setAccessible(true);
-        hostAndPost.set(elasticSearchConfig, "localhost:9200");
+        Field host = ElasticSearchConfig.class.getDeclaredField("host");
+        host.setAccessible(true);
+        host.set(elasticSearchConfig, "localhost");
 
+        Field port = ElasticSearchConfig.class.getDeclaredField("port");
+        port.setAccessible(true);
+        port.set(elasticSearchConfig, "8080");
+
+        Field username = ElasticSearchConfig.class.getDeclaredField("username");
+        username.setAccessible(true);
+        username.set(elasticSearchConfig, "username");
+
+        Field password = ElasticSearchConfig.class.getDeclaredField("password");
+        password.setAccessible(true);
+        password.set(elasticSearchConfig, "8080");
         // when // then
-        Assertions.assertDoesNotThrow(elasticSearchConfig::clientConfiguration);
+        Assertions.assertDoesNotThrow(elasticSearchConfig::elasticsearchClient);
     }
 
 }

--- a/src/test/java/me/honki12345/hoonlog/config/ElasticTestContainerConfig.java
+++ b/src/test/java/me/honki12345/hoonlog/config/ElasticTestContainerConfig.java
@@ -4,12 +4,14 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import me.honki12345.hoonlog.repository.elasticsearch.PostSearchRepository;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchCustomConversions;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
@@ -19,7 +21,7 @@ import org.testcontainers.utility.DockerImageName;
 @EnableElasticsearchRepositories(basePackageClasses = {PostSearchRepository.class})
 public class ElasticTestContainerConfig extends ElasticSearchConfig {
 
-    private static final String ELASTICSEARCH_VERSION = "7.15.2";
+    private static final String ELASTICSEARCH_VERSION = "7.10.2";
     private static final DockerImageName ELASTICSEARCH_IMAGE =
         DockerImageName
             .parse("docker.elastic.co/elasticsearch/elasticsearch")
@@ -32,10 +34,11 @@ public class ElasticTestContainerConfig extends ElasticSearchConfig {
     }
 
     @Override
-    public ClientConfiguration clientConfiguration() {
-        return ClientConfiguration.builder()
+    public RestHighLevelClient elasticsearchClient() {
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
             .connectedTo(container.getHttpHostAddress())
             .build();
+        return RestClients.create(clientConfiguration).rest();
     }
 
     @Bean


### PR DESCRIPTION
- elasticsearch 서버의 버전을 7.10 으로 맞춘다.
  - aws opensearch 의 elasticsearch 버전을 7.10 으로 한다.
- elasticsearch 서버의 버전이 낮추어짐에 따라 스프링부트에서 elasticsearch client 버전도 낮추고 이에 맞는 설정을 변경한다.