### PR TITLE
API 문서 자동화(Swagger): 환경별 server url 지정

### DIFF
--- a/src/main/java/me/honki12345/hoonlog/config/SwaggerConfig.java
+++ b/src/main/java/me/honki12345/hoonlog/config/SwaggerConfig.java
@@ -2,10 +2,14 @@ package me.honki12345.hoonlog.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @OpenAPIDefinition(
     info = @Info(title = "hoonlog API 명세서",
@@ -23,6 +27,9 @@ public class SwaggerConfig {
         return GroupedOpenApi.builder()
             .group("hoonlog API v1")
             .pathsToMatch(paths)
+            .addOpenApiCustomizer(openApi -> openApi.setServers(
+                List.of(new Server().description("prod").url("http://hoon-log.p-e.kr"),
+                    new Server().description("dev").url("http://localhost:8080"))))
             .build();
     }
 


### PR DESCRIPTION
### 진행
- 배포환경에서는 `http://hoon-log.p-e.kr`로 server url을 지정하고,
개발환경에서는 `localhost:8080`으로 server url을 지정한다.